### PR TITLE
v6.7

### DIFF
--- a/src/application/task/room_keeper/task_request_handler/spawn_request_handler.ts
+++ b/src/application/task/room_keeper/task_request_handler/spawn_request_handler.ts
@@ -51,17 +51,22 @@ export class SpawnRequestHandler {
           if (futureRequest == null) {
             return null
           }
+          futureRequests.shift()
           return futureRequest
         }
         if (futureRequest == null) {
+          currentRequests.shift()
           return currentRequest
         }
         if (currentRequest.spawnTimeCost < futureRequest.neededIn) {
+          currentRequests.shift()
           return currentRequest
         }
         if (currentRequest.priority < futureRequest.priority) {
+          currentRequests.shift()
           return currentRequest
         } else {
+          futureRequests.shift()
           return futureRequest
         }
       })()

--- a/src/application/task/wall/wall_builder_task.ts
+++ b/src/application/task/wall/wall_builder_task.ts
@@ -16,6 +16,8 @@ import { WithdrawApiWrapper } from "object_task/creep_task/api_wrapper/withdraw_
 import { BuildWallTask } from "object_task/creep_task/task/build_wall_task"
 import { RepairApiWrapper } from "object_task/creep_task/api_wrapper/repair_api_wrapper"
 
+export const WallBuilderTaskMaxWallHits = 5000000
+
 const wallTypes: StructureConstant[] = [
   STRUCTURE_WALL,
   STRUCTURE_RAMPART,
@@ -79,7 +81,7 @@ export class WallBuilderTask extends Task<WallBuilderTaskOutput, WallBuilderTask
         + (roomResource.activeStructures.terminal?.store.getUsedCapacity(RESOURCE_ENERGY) ?? 0)
 
       if (energyAmount > 80000) {
-        const maxHits = roomResource.activeStructures.terminal == null ? 2000000 : 5000000
+        const maxHits = roomResource.activeStructures.terminal == null ? 2000000 : WallBuilderTaskMaxWallHits
         const walls: (StructureWall | StructureRampart)[] = [
           ...roomResource.walls,
           ...roomResource.ramparts,

--- a/src/game/game_info.ts
+++ b/src/game/game_info.ts
@@ -1,4 +1,6 @@
 export interface GameInfoMemory {
   whitelist: string[]
   sourceHarvestWhitelist: string[]
+  disableEnergyTransfer?: boolean
+  disableResourceTransfer?: boolean
 }

--- a/src/game/sign.ts
+++ b/src/game/sign.ts
@@ -1,7 +1,7 @@
 import { SystemInfo } from "utility/system_info"
 
 export const Sign = {
-  sign: function (room: Room): string {
+  sign(room: Room): string {
     if (room.controller == null) {
       return ""
     }
@@ -11,7 +11,12 @@ export const Sign = {
       return `at ${Game.time}`
     }
   },
-  signForOwnedRoom: function (): string {
+
+  signForOwnedRoom(): string {
     return `v${SystemInfo.application.version} at ${Game.time}`
+  },
+
+  signForHostileRoom(): string {
+    return "🍣"
   },
 }

--- a/src/knowledge/cpu_time_profile.ts
+++ b/src/knowledge/cpu_time_profile.ts
@@ -1,5 +1,34 @@
 
 /*
+shard 3
+calls		time		avg		function
+2631		658.0		0.250		Creep.moveTo
+2332		479.6		0.206		Creep.move
+1964		417.4		0.213		Creep.moveByPath
+2641		224.9		0.085		Creep.withdraw
+963		161.4		0.168		Creep.harvest
+600		134.3		0.224		Creep.upgradeController
+1616		103.0		0.064		Creep.transfer
+367		99.9		0.272		RoomPosition.findPathTo
+367		95.4		0.260		Room.findPath
+741		45.8		0.062		Room.createConstructionSite
+193		41.1		0.213		Creep.repair
+10235		29.2		0.003		Room.find
+100		22.0		0.220		Creep.reserveController
+7897		17.0		0.002		RoomPosition.getRangeTo
+5544		12.6		0.002		RoomPosition.isNearTo
+6007		11.1		0.002		RoomPosition.encode
+3041		5.9		0.002		RoomPosition.isEqualTo
+619		5.8		0.009		RoomPosition.findInRange
+1364		4.0		0.003		RoomPosition.inRangeTo
+253		3.2		0.013		RoomPosition.lookFor
+187		3.1		0.017		RoomPosition.findClosestByPath
+9		1.8		0.199		Spawn.spawnCreep
+253		1.8		0.007		Room.lookForAt
+76		1.4		0.018		Creep.pickup
+117		1.0		0.008		Creep.say
+Avg: 23.05	Total: 2259.25	Ticks: 98
+
 Season 3
 calls		time		avg		function
 10419		2536.6		0.243		Creep.moveTo

--- a/src/knowledge/cpu_time_profile.ts
+++ b/src/knowledge/cpu_time_profile.ts
@@ -1,5 +1,34 @@
 
 /*
+Season 3
+calls		time		avg		function
+10419		2536.6		0.243		Creep.moveTo
+9534		1952.5		0.205		Creep.move
+7755		1632.6		0.211		Creep.moveByPath
+18985		1343.9		0.071		RoomPosition.isNearTo
+3879		761.0		0.196		Creep.harvest
+1201		425.4		0.354		RoomPosition.findPathTo
+1201		413.6		0.344		Room.findPath
+4750		395.4		0.083		Creep.withdraw
+1522		321.8		0.211		Creep.repair
+1100		247.0		0.225		Creep.upgradeController
+885		174.2		0.197		Creep.reserveController
+5226		169.5		0.032		Creep.transfer
+43219		160.2		0.004		Room.find
+3358		133.6		0.040		RoomPosition.findInRange
+726		132.0		0.182		Creep.heal
+2085		51.1		0.024		RoomPosition.findClosestByPath
+234		45.5		0.194		Creep.attack
+21568		39.9		0.002		RoomPosition.getRangeTo
+26569		39.8		0.001		RoomPosition.inRangeTo
+372		38.9		0.105		RoomPosition.positionsInRange
+19056		28.2		0.001		RoomPosition.encode
+1902		27.4		0.014		Creep.pickup
+2859		25.4		0.009		RoomPosition.lookFor
+2976		24.9		0.008		RoomPosition.look
+Avg: 92.52	Total: 9067.34	Ticks: 98
+
+Shard3
 calls		time		avg		function
 2477		610.7		0.247		Creep.moveTo
 2105		434.4		0.206		Creep.move

--- a/src/knowledge/cpu_time_profile.ts
+++ b/src/knowledge/cpu_time_profile.ts
@@ -1,5 +1,32 @@
 
 /*
+calls		time		avg		function
+2477		610.7		0.247		Creep.moveTo
+2105		434.4		0.206		Creep.move
+1713		365.2		0.213		Creep.moveByPath
+2209		176.2		0.080		Creep.withdraw
+779		153.9		0.198		Creep.harvest
+556		108.7		0.195		Creep.upgradeController
+406		94.4		0.233		RoomPosition.findPathTo
+406		89.7		0.221		Room.findPath
+1506		88.0		0.058		Creep.transfer
+283		57.8		0.204		Creep.repair
+10184		33.6		0.003		Room.find
+672		29.7		0.044		Room.createConstructionSite
+7743		16.2		0.002		RoomPosition.getRangeTo
+507		16.1		0.032		RoomPosition.findInRange
+5054		14.0		0.003		Creep.notifyWhenAttacked
+4791		11.5		0.002		RoomPosition.isNearTo
+5420		10.8		0.002		RoomPosition.encode
+3033		7.7		0.003		RoomPosition.inRangeTo
+2929		5.8		0.002		RoomPosition.isEqualTo
+328		5.5		0.017		RoomPosition.findClosestByPath
+296		4.2		0.014		RoomPosition.lookFor
+219		3.8		0.017		Creep.pickup
+38		3.6		0.094		Creep.reserveController
+12		3.3		0.275		Spawn.spawnCreep
+Avg: 21.66	Total: 2123.07	Ticks: 98
+
 Quad
 calls		time		avg		function
 10371		2349.2		0.227		Creep.moveTo

--- a/src/object_task/creep_task/task/move_to_room_task.ts
+++ b/src/object_task/creep_task/task/move_to_room_task.ts
@@ -95,7 +95,20 @@ export class MoveToRoomTask implements CreepTask {
       return nextWaypoint
     })()
 
-    const reusePath = 20
+    const reusePath = ((): number => {
+      const defaultValue = 20
+      const controller = creep.room.controller
+      if (controller == null) {
+        return defaultValue
+      }
+      if (controller.owner != null) {
+        return 3
+      }
+      if (controller.reservation != null) {
+        return 5
+      }
+      return defaultValue
+    })()
     const noPathFindingOptions: MoveToOpts = {
       noPathFinding: true,
       reusePath,

--- a/src/os/infrastructure/console_command/exec_command.ts
+++ b/src/os/infrastructure/console_command/exec_command.ts
@@ -496,7 +496,7 @@ export class ExecCommand implements ConsoleCommand {
     }
   }
 
-  // Game.io("exec set_boost_labs room_name=W54S7 labs=5b9982765d439a46dcd0333c,5ba123b99b6fbc04b99ab258,5bb2a960c7713c07c244ab59,5bb38b5a0f67111d8408385d,5bb3aa128c52350adbf74014")
+  // Game.io("exec set_boost_labs room_name=W48S6 labs=5b3ec0561ca96b59438c5536,5b4f220fd871ba7bf45aa186,5b4f51ece15e100251fad206,5b35bcb1cb21c464f0ca2a2c,5b3ec6854e66ea3377c7b2b4")
   private setBoostLabs(): CommandExecutionResult {
     const outputs: string[] = []
 

--- a/src/os/infrastructure/console_command/launch_command.ts
+++ b/src/os/infrastructure/console_command/launch_command.ts
@@ -813,9 +813,25 @@ export class LaunchCommand implements ConsoleCommand {
       return this.missingArgumentError("waypoints")
     }
     const waypoints = rawWaypoints.split(",")
+    const rawFinishWorking = args.get("finish_working")
+    if (rawFinishWorking == null) {
+      return this.missingArgumentError("finish_working")
+    }
+    const finishWorking = parseInt(rawFinishWorking, 10)
+    if (isNaN(finishWorking) === true) {
+      return Result.Failed(`finish_working is not a number ${rawFinishWorking}`)
+    }
+    const rawNumberOfCreeps = args.get("creeps")
+    if (rawNumberOfCreeps == null) {
+      return this.missingArgumentError("creeps")
+    }
+    const numberOfCreeps = parseInt(rawNumberOfCreeps, 10)
+    if (isNaN(numberOfCreeps) === true) {
+      return Result.Failed(`creeps is not a number ${rawNumberOfCreeps}`)
+    }
 
     const process = OperatingSystem.os.addProcess(processId => {
-      return Season1521073SendResourceProcess.create(processId, roomName, targetRoomName, waypoints)
+      return Season1521073SendResourceProcess.create(processId, roomName, targetRoomName, waypoints, finishWorking, numberOfCreeps)
     })
     return Result.Succeeded(process)
   }

--- a/src/os/infrastructure/console_command/launch_command.ts
+++ b/src/os/infrastructure/console_command/launch_command.ts
@@ -46,6 +46,7 @@ import { isQuadType, quadTypes } from "process/onetime/season_1673282_specialize
 import { Season2006098StealResourceProcess } from "process/onetime/season_2006098_steal_resource_process"
 import { Season2055924SendResourcesProcess } from "process/onetime/season_2055924_send_resources_process"
 import { InterRoomResourceManagementProcess } from "process/process/inter_room_resource_management_process"
+import { World35440623DowngradeControllerProcess } from "process/onetime/world_35440623_downgrade_controller_process"
 
 type LaunchCommandResult = Result<Process, string>
 
@@ -163,6 +164,9 @@ export class LaunchCommand implements ConsoleCommand {
       break
     case "InterRoomResourceManagementProcess":
       result = this.launchInterRoomResourceManagementProcess()
+      break
+    case "World35440623DowngradeControllerProcess":
+      result = this.launchWorld35440623DowngradeControllerProcess()
       break
     default:
       break
@@ -1056,6 +1060,25 @@ export class LaunchCommand implements ConsoleCommand {
   private launchInterRoomResourceManagementProcess(): LaunchCommandResult {
     const process = OperatingSystem.os.addProcess(processId => {
       return InterRoomResourceManagementProcess.create(processId)
+    })
+    return Result.Succeeded(process)
+  }
+
+  private launchWorld35440623DowngradeControllerProcess(): LaunchCommandResult {
+    const args = this.parseProcessArguments()
+
+    const roomName = args.get("room_name")
+    if (roomName == null) {
+      return this.missingArgumentError("room_name")
+    }
+    const rawTargetRoomNames = args.get("target_room_names")
+    if (rawTargetRoomNames == null) {
+      return this.missingArgumentError("target_room_names")
+    }
+    const targetRoomNames = rawTargetRoomNames.split(",")
+
+    const process = OperatingSystem.os.addProcess(processId => {
+      return World35440623DowngradeControllerProcess.create(processId, roomName, targetRoomNames)
     })
     return Result.Succeeded(process)
   }

--- a/src/os/infrastructure/process_launcher/application_process_launcher.ts
+++ b/src/os/infrastructure/process_launcher/application_process_launcher.ts
@@ -11,11 +11,13 @@ import { V6RoomKeeperProcess } from "process/v6_room_keeper_process"
 import { RoomKeeperTask } from "application/task/room_keeper/room_keeper_task"
 import { PrimitiveLogger } from "../primitive_logger"
 import { coloredText, roomLink } from "utility/log"
+import { Season487837AttackInvaderCoreProcess } from "process/onetime/season_487837_attack_invader_core_process"
 
 export class ApplicationProcessLauncher {
   public launchProcess(processList: Process[], processLauncher: ProcessLauncher): void {
     this.checkRoomKeeperProcess(processList, processLauncher)
     this.checkBoostrapRoomManagerProcess(processList, processLauncher)
+    this.checkAttackInvaderCoreProcess(processList, processLauncher)
   }
 
   private checkRoomKeeperProcess(processList: Process[], processLauncher: ProcessLauncher): void {
@@ -70,5 +72,12 @@ export class ApplicationProcessLauncher {
       return
     }
     processLauncher(processId => BootstrapRoomManagerProcess.create(processId))
+  }
+
+  private checkAttackInvaderCoreProcess(processList: Process[], processLauncher: ProcessLauncher): void {
+    if (processList.some(process => process instanceof Season487837AttackInvaderCoreProcess) === true) {
+      return
+    }
+    processLauncher(processId => Season487837AttackInvaderCoreProcess.create(processId))
   }
 }

--- a/src/process/bootstrap_room_manager_process.ts
+++ b/src/process/bootstrap_room_manager_process.ts
@@ -22,7 +22,7 @@ export interface BootstrapRoomManagerProcessState extends ProcessState {
 
 // Game.io("message 544054000 parent_room_name=W9S24 target_room_name=W5S21 waypoints=W10S24,W10S20,W5S20 target_gcl=11")
 // Game.io("message 29614512000 parent_room_name=W51S29 target_room_name=W48S33 waypoints=W50S30,W50S33 target_gcl=42")
-// Game.io("message 34351858000 parent_room_name=W48S6 target_room_name=W41S4 waypoints=W43S5 target_gcl=42")
+// Game.io("message 34351858000 parent_room_name=W48S12 target_room_name=W42S3 waypoints=W48S10,W47S10,W47S7,W44S6 claim_parent_room_name=W43S5 target_gcl=42")
 export class BootstrapRoomManagerProcess implements Process, Procedural, MessageObserver {
   private constructor(
     public readonly launchTime: number,

--- a/src/process/bootstrap_room_manager_process.ts
+++ b/src/process/bootstrap_room_manager_process.ts
@@ -22,7 +22,7 @@ export interface BootstrapRoomManagerProcessState extends ProcessState {
 
 // Game.io("message 544054000 parent_room_name=W9S24 target_room_name=W5S21 waypoints=W10S24,W10S20,W5S20 target_gcl=11")
 // Game.io("message 29614512000 parent_room_name=W51S29 target_room_name=W48S33 waypoints=W50S30,W50S33 target_gcl=42")
-// Game.io("message 34351858000 parent_room_name=W48S6 target_room_name=W48S4 waypoints=W48S4 target_gcl=42")
+// Game.io("message 34351858000 parent_room_name=W48S6 target_room_name=W41S7 waypoints=W48S7 claim_parent_room_name=W43S7 claim_waypoints=W41S7 target_gcl=42")
 export class BootstrapRoomManagerProcess implements Process, Procedural, MessageObserver {
   private constructor(
     public readonly launchTime: number,

--- a/src/process/bootstrap_room_manager_process.ts
+++ b/src/process/bootstrap_room_manager_process.ts
@@ -22,7 +22,7 @@ export interface BootstrapRoomManagerProcessState extends ProcessState {
 
 // Game.io("message 544054000 parent_room_name=W9S24 target_room_name=W5S21 waypoints=W10S24,W10S20,W5S20 target_gcl=11")
 // Game.io("message 29614512000 parent_room_name=W51S29 target_room_name=W48S33 waypoints=W50S30,W50S33 target_gcl=42")
-// Game.io("message 34351858000 parent_room_name=W48S6 target_room_name=W47S4 waypoints=W48S3 target_gcl=42")
+// Game.io("message 34351858000 parent_room_name=W48S6 target_room_name=W49S6 waypoints=W49S6 target_gcl=42")
 export class BootstrapRoomManagerProcess implements Process, Procedural, MessageObserver {
   private constructor(
     public readonly launchTime: number,

--- a/src/process/bootstrap_room_manager_process.ts
+++ b/src/process/bootstrap_room_manager_process.ts
@@ -22,7 +22,7 @@ export interface BootstrapRoomManagerProcessState extends ProcessState {
 
 // Game.io("message 544054000 parent_room_name=W9S24 target_room_name=W5S21 waypoints=W10S24,W10S20,W5S20 target_gcl=11")
 // Game.io("message 29614512000 parent_room_name=W51S29 target_room_name=W48S33 waypoints=W50S30,W50S33 target_gcl=42")
-// Game.io("message 34351858000 parent_room_name=W48S12 target_room_name=W53S17 waypoints=W48S11,W50S11,W50S16,W53S16 target_gcl=42")
+// Game.io("message 34351858000 parent_room_name=W55S9 target_room_name=W59S13 waypoints=W56S9,W56S8,W57S8,W59S10 target_gcl=42")
 export class BootstrapRoomManagerProcess implements Process, Procedural, MessageObserver {
   private constructor(
     public readonly launchTime: number,

--- a/src/process/bootstrap_room_manager_process.ts
+++ b/src/process/bootstrap_room_manager_process.ts
@@ -22,7 +22,7 @@ export interface BootstrapRoomManagerProcessState extends ProcessState {
 
 // Game.io("message 544054000 parent_room_name=W9S24 target_room_name=W5S21 waypoints=W10S24,W10S20,W5S20 target_gcl=11")
 // Game.io("message 29614512000 parent_room_name=W51S29 target_room_name=W48S33 waypoints=W50S30,W50S33 target_gcl=42")
-// Game.io("message 34351858000 parent_room_name=W48S6 target_room_name=W45S3 waypoints=W48S7,W45S7 target_gcl=42")
+// Game.io("message 34351858000 parent_room_name=W54S7 target_room_name=W44S8 waypoints=W50S7,W48S6,W47S9 claim_parent_room_name=W48S12 claim_waypoints=W47S9 target_gcl=42")
 export class BootstrapRoomManagerProcess implements Process, Procedural, MessageObserver {
   private constructor(
     public readonly launchTime: number,

--- a/src/process/bootstrap_room_manager_process.ts
+++ b/src/process/bootstrap_room_manager_process.ts
@@ -22,7 +22,7 @@ export interface BootstrapRoomManagerProcessState extends ProcessState {
 
 // Game.io("message 544054000 parent_room_name=W9S24 target_room_name=W5S21 waypoints=W10S24,W10S20,W5S20 target_gcl=11")
 // Game.io("message 29614512000 parent_room_name=W51S29 target_room_name=W48S33 waypoints=W50S30,W50S33 target_gcl=42")
-// Game.io("message 34351858000 parent_room_name=W48S6 target_room_name=W49S6 waypoints=W49S6 target_gcl=42")
+// Game.io("message 34351858000 parent_room_name=W48S6 target_room_name=W41S4 waypoints=W43S5 target_gcl=42")
 export class BootstrapRoomManagerProcess implements Process, Procedural, MessageObserver {
   private constructor(
     public readonly launchTime: number,

--- a/src/process/bootstrap_room_manager_process.ts
+++ b/src/process/bootstrap_room_manager_process.ts
@@ -22,7 +22,7 @@ export interface BootstrapRoomManagerProcessState extends ProcessState {
 
 // Game.io("message 544054000 parent_room_name=W9S24 target_room_name=W5S21 waypoints=W10S24,W10S20,W5S20 target_gcl=11")
 // Game.io("message 29614512000 parent_room_name=W51S29 target_room_name=W48S33 waypoints=W50S30,W50S33 target_gcl=42")
-// Game.io("message 34351858000 parent_room_name=W48S12 target_room_name=W42S3 waypoints=W48S10,W47S10,W47S7,W44S6 claim_parent_room_name=W43S5 target_gcl=42")
+// Game.io("message 34351858000 parent_room_name=W48S6 target_room_name=W48S4 waypoints=W48S4 target_gcl=42")
 export class BootstrapRoomManagerProcess implements Process, Procedural, MessageObserver {
   private constructor(
     public readonly launchTime: number,

--- a/src/process/bootstrap_room_manager_process.ts
+++ b/src/process/bootstrap_room_manager_process.ts
@@ -22,7 +22,7 @@ export interface BootstrapRoomManagerProcessState extends ProcessState {
 
 // Game.io("message 544054000 parent_room_name=W9S24 target_room_name=W5S21 waypoints=W10S24,W10S20,W5S20 target_gcl=11")
 // Game.io("message 29614512000 parent_room_name=W51S29 target_room_name=W48S33 waypoints=W50S30,W50S33 target_gcl=42")
-// Game.io("message 34351858000 parent_room_name=W55S9 target_room_name=W59S13 waypoints=W56S9,W56S8,W57S8,W59S10 target_gcl=42")
+// Game.io("message 34351858000 parent_room_name=W48S6 target_room_name=W45S3 waypoints=W48S7,W45S7 target_gcl=42")
 export class BootstrapRoomManagerProcess implements Process, Procedural, MessageObserver {
   private constructor(
     public readonly launchTime: number,

--- a/src/process/bootstrap_room_manager_process.ts
+++ b/src/process/bootstrap_room_manager_process.ts
@@ -22,7 +22,7 @@ export interface BootstrapRoomManagerProcessState extends ProcessState {
 
 // Game.io("message 544054000 parent_room_name=W9S24 target_room_name=W5S21 waypoints=W10S24,W10S20,W5S20 target_gcl=11")
 // Game.io("message 29614512000 parent_room_name=W51S29 target_room_name=W48S33 waypoints=W50S30,W50S33 target_gcl=42")
-// Game.io("message 34351858000 parent_room_name=W54S7 target_room_name=W44S8 waypoints=W50S7,W48S6,W47S9 claim_parent_room_name=W48S12 claim_waypoints=W47S9 target_gcl=42")
+// Game.io("message 34351858000 parent_room_name=W48S6 target_room_name=W43S5 waypoints=W47S7 target_gcl=42")
 export class BootstrapRoomManagerProcess implements Process, Procedural, MessageObserver {
   private constructor(
     public readonly launchTime: number,

--- a/src/process/onetime/season_1244215_generic_dismantle_process.ts
+++ b/src/process/onetime/season_1244215_generic_dismantle_process.ts
@@ -35,7 +35,7 @@ export interface Season1244215GenericDismantleProcessState extends ProcessState 
   creepName: CreepName | null
 }
 
-// Game.io("launch -l Season1244215GenericDismantleProcess room_name=W48S6 target_room_name=W47S8 waypoints=W47S8 target_id=606af6a0ba95066cfbef01fd")
+// Game.io("launch -l Season1244215GenericDismantleProcess room_name=W48S12 target_room_name=W45S9 waypoints=W47S10,W46S10,W44S9 target_id=5fff73b0ed5e41453a568e63")
 export class Season1244215GenericDismantleProcess implements Process, Procedural, MessageObserver {
   public readonly identifier: string
   private readonly codename: string

--- a/src/process/onetime/season_1262745_guard_remote_room_process.ts
+++ b/src/process/onetime/season_1262745_guard_remote_room_process.ts
@@ -78,14 +78,7 @@ export interface Season1262745GuardRemoteRoomProcessState extends ProcessState {
   numberOfCreeps: number
 }
 
-// W21S15
-// Game.io("launch -l Season1262745GuardRemoteRoomProcess room_name=W21S23 target_room_name=W21S15 waypoints=W20S23,W20S14 creep_type=heavy-ranged-attacker creeps=1")
-
-// W17S11
-// Game.io("launch -l Season1262745GuardRemoteRoomProcess room_name=W21S23 target_room_name=W17S11 waypoints=W20S23,W20S10,W17S10 creep_type=heavy-ranged-attacker creeps=2")
-
-// W25S22
-// Game.io("launch -l Season1262745GuardRemoteRoomProcess room_name=W21S23 target_room_name=W25S22 waypoints=W20S23,W20S20,W23S20,W23S21,W24S21,W24S22 creep_type=ranged-attacker creeps=2")
+// Game.io("launch -l Season1262745GuardRemoteRoomProcess room_name=W48S12 target_room_name=W47S9 waypoints=W48S10,W47S10 creep_type=heavy-ranged-attacker creeps=1")
 export class Season1262745GuardRemoteRoomProcess implements Process, Procedural {
   public readonly identifier: string
   private readonly codename: string

--- a/src/process/onetime/season_1673282_specialized_quad.ts
+++ b/src/process/onetime/season_1673282_specialized_quad.ts
@@ -929,7 +929,7 @@ export class Quad implements Stateful, QuadInterface {
       if (previousCreep == null || previousCreep.spawning === true || creep == null) {
         return
       }
-      creep.moveTo(previousCreep.pos, this.moveToOptions(2))
+      creep.moveTo(previousCreep.pos, this.moveToOptions(2, false))
     }
 
     follow(1)

--- a/src/process/onetime/season_1673282_specialized_quad.ts
+++ b/src/process/onetime/season_1673282_specialized_quad.ts
@@ -1213,26 +1213,26 @@ function quadCostCallback(excludedCreepNames: CreepName[], quadDirection: Direct
       case TOP:
         return [
           TOP,
-          TOP_RIGHT,
           RIGHT,
+          TOP_RIGHT,
         ]
       case RIGHT:
         return [
           RIGHT,
-          BOTTOM_RIGHT,
           BOTTOM,
+          BOTTOM_RIGHT,
         ]
       case BOTTOM:
         return [
           BOTTOM,
-          BOTTOM_LEFT,
           LEFT,
+          BOTTOM_LEFT,
         ]
       case LEFT:
         return [
           LEFT,
-          TOP_LEFT,
           TOP,
+          TOP_LEFT,
         ]
       }
     })()

--- a/src/process/onetime/season_1673282_specialized_quad.ts
+++ b/src/process/onetime/season_1673282_specialized_quad.ts
@@ -769,10 +769,12 @@ export class Quad implements Stateful, QuadInterface {
     })()
 
     if (leaderRotationPosition != null) {
+      // if (this.isQuadForm() === true) {
       this.say("rotate")
       this.leaderCreep.moveTo(leaderRotationPosition, this.moveToOptions(1))  // FixMe: target room直前でrotateしようとしてclose to destinationから抜けてしまうのではないか
       this.moveFollowersToNexPosition(leaderRotationPosition)
       return
+      // }
     }
 
     const leaderAvoidEdgePosition = ((): RoomPosition => {

--- a/src/process/onetime/season_1673282_specialized_quad_process.ts
+++ b/src/process/onetime/season_1673282_specialized_quad_process.ts
@@ -105,18 +105,21 @@ export interface Season1673282SpecializedQuadProcessState extends ProcessState {
 
 // W51S7 tier3-3tower-dismantler
 // Game.io("launch -l Season1673282SpecializedQuadProcess room_name=W54S7 target_room_name=W51S7 waypoints=W51S7 quad_type=tier3-3tower-dismantler targets=")
+
+// W47S7 tier3-6tower-dismantler
+// Game.io("launch -l Season1673282SpecializedQuadProcess room_name=W48S6 target_room_name=W47S7 waypoints=W48S7 quad_type=tier3-6tower-dismantler targets=")
 export class Season1673282SpecializedQuadProcess implements Process, Procedural, MessageObserver {
   public readonly identifier: string
-  private readonly codename: string
 
+  private readonly codename: string
   private readonly quadSpec: QuadSpec
 
   private constructor(
     public readonly launchTime: number,
     public readonly processId: ProcessId,
     public readonly parentRoomName: RoomName,
-    public readonly targetRoomName: RoomName,
-    public readonly waypoints: RoomName[],
+    public targetRoomName: RoomName,
+    public waypoints: RoomName[],
     private readonly quadType: QuadType,
     private readonly creepNames: CreepName[],
     private quadState: QuadState | null,
@@ -233,6 +236,20 @@ export class Season1673282SpecializedQuadProcess implements Process, Procedural,
       }
       this.quadState.nextDirection = direction as TOP | BOTTOM | RIGHT | LEFT
       return `direction ${coloredText(directionName(direction as TOP | BOTTOM | RIGHT | LEFT), "info")} set`
+    }
+    if (message.startsWith("change target ")) {
+      const rawRooms = message.slice(14)
+      const roomNames = rawRooms.split(",")
+      if (rawRooms.length <= 0 || roomNames.length <= 0) {
+        return "no target room specified"
+      }
+      const targetRoomName = roomNames.pop()
+      if (targetRoomName == null) {
+        return "can't retrieve target room"
+      }
+      this.waypoints = roomNames
+      this.targetRoomName = targetRoomName
+      return `target room: ${this.targetRoomName}, waypoints: ${roomNames} set`
     }
     if (message.length <= 0) {
       return "Empty message"
@@ -517,6 +534,7 @@ export class Season1673282SpecializedQuadProcess implements Process, Procedural,
 
     const targetPriority = ((): StructureConstant[] => {
       return [ // 添字の大きい方が優先
+        STRUCTURE_LAB,
         STRUCTURE_POWER_SPAWN,
         STRUCTURE_TERMINAL,
         STRUCTURE_EXTENSION,

--- a/src/process/onetime/season_1673282_specialized_quad_process.ts
+++ b/src/process/onetime/season_1673282_specialized_quad_process.ts
@@ -1,6 +1,6 @@
 import { Procedural } from "process/procedural"
 import { Process, ProcessId } from "process/process"
-import { RoomCoordinate, RoomName } from "utility/room_name"
+import { isRoomName, RoomCoordinate, RoomName } from "utility/room_name"
 import { coloredResourceType, coloredText, roomLink } from "utility/log"
 import { ProcessState } from "process/process_state"
 import { CreepRole } from "prototype/creep_role"
@@ -242,6 +242,9 @@ export class Season1673282SpecializedQuadProcess implements Process, Procedural,
       const roomNames = rawRooms.split(",")
       if (rawRooms.length <= 0 || roomNames.length <= 0) {
         return "no target room specified"
+      }
+      if (roomNames.some(roomName => !isRoomName(roomName)) === true) {
+        return `invalid room name ${roomNames}`
       }
       const targetRoomName = roomNames.pop()
       if (targetRoomName == null) {

--- a/src/process/onetime/season_1673282_specialized_quad_process.ts
+++ b/src/process/onetime/season_1673282_specialized_quad_process.ts
@@ -26,7 +26,7 @@ type AttackTarget = AnyCreep | AnyStructure
 type ManualOperations = {
   targetIds: Id<AttackTarget>[]
   direction: TOP | BOTTOM | LEFT | RIGHT | null
-  action: "flee" | "drain" | null
+  action: "flee" | "noflee" | "drain" | null
   message: string | null
   automaticRotationEnabled: boolean | null
 }
@@ -108,6 +108,8 @@ export interface Season1673282SpecializedQuadProcessState extends ProcessState {
 
 // W47S7 tier3-6tower-dismantler
 // Game.io("launch -l Season1673282SpecializedQuadProcess room_name=W48S6 target_room_name=W47S7 waypoints=W48S7 quad_type=tier3-6tower-dismantler targets=")
+
+// Game.io("launch -l Season1673282SpecializedQuadProcess room_name=W48S6 target_room_name=W47S9 waypoints=W47S9 quad_type=tier0-d360-dismantler targets=")
 export class Season1673282SpecializedQuadProcess implements Process, Procedural, MessageObserver {
   public readonly identifier: string
 
@@ -189,6 +191,10 @@ export class Season1673282SpecializedQuadProcess implements Process, Procedural,
     if (message === "flee") {
       this.manualOperations.action = "flee"
       return "action: flee"
+    }
+    if (message === "noflee") {
+      this.manualOperations.action = "noflee"
+      return "action: noflee"
     }
     if (message === "drain") {
       this.manualOperations.action = "drain"
@@ -399,7 +405,7 @@ export class Season1673282SpecializedQuadProcess implements Process, Procedural,
       }
     }
 
-    if (quad.damagePercent * 4 > 0.15) {
+    if (this.manualOperations.action !== "noflee" && quad.damagePercent * 4 > 0.15) {
       const { succeeded } = this.flee(quad)
       if (succeeded === true) {
         return
@@ -414,6 +420,8 @@ export class Season1673282SpecializedQuadProcess implements Process, Procedural,
       }
       break
     }
+    case "noflee":
+      break
     case "drain":
       if (this.towerCharged(quad.room) === true) {
         this.drain(quad)

--- a/src/process/onetime/season_1673282_specialized_quad_process.ts
+++ b/src/process/onetime/season_1673282_specialized_quad_process.ts
@@ -111,12 +111,12 @@ export interface Season1673282SpecializedQuadProcessState extends ProcessState {
 
 // W46S9 tier3-6tower-dismantler
 // [Boost Needed]: XZHO2: 1200, XZH2O: 540, XGHO2: 2640, XLHO2: 720, XKHO2: 900
-// Game.io("launch -l Season1673282SpecializedQuadProcess room_name=W48S6 target_room_name=W49S5 waypoints=W48S5 quad_type=tier3-6tower-dismantler targets=")
+// Game.io("launch -l Season1673282SpecializedQuadProcess room_name=W48S6 target_room_name=W49S4 waypoints=W48S5 quad_type=tier3-6tower-dismantler targets=")
 
 // W43S5 invader-core-attacker
 // Game.io("launch -l Season1673282SpecializedQuadProcess room_name=W48S6 target_room_name=W43S5 waypoints=W47S7 quad_type=invader-core-attacker targets=")
 
-// Game.io("launch -l Season1673282SpecializedQuadProcess room_name=W48S6 target_room_name=W46S5 waypoints=W47S7,W46S7 quad_type=tier1-invader-core-lv1 targets=")
+// Game.io("launch -l Season1673282SpecializedQuadProcess room_name=W48S6 target_room_name=W44S3 waypoints=W48S3,W47S3,W44S4 quad_type=tier3-6tower-tank targets=")
 export class Season1673282SpecializedQuadProcess implements Process, Procedural, MessageObserver {
   public readonly identifier: string
 
@@ -552,6 +552,7 @@ export class Season1673282SpecializedQuadProcess implements Process, Procedural,
 
     const targetPriority = ((): StructureConstant[] => {
       return [ // 添字の大きい方が優先
+        STRUCTURE_INVADER_CORE,
         STRUCTURE_LAB,
         STRUCTURE_POWER_SPAWN,
         STRUCTURE_TERMINAL,

--- a/src/process/onetime/season_1673282_specialized_quad_process.ts
+++ b/src/process/onetime/season_1673282_specialized_quad_process.ts
@@ -109,7 +109,8 @@ export interface Season1673282SpecializedQuadProcessState extends ProcessState {
 // W47S7 tier3-6tower-dismantler
 // Game.io("launch -l Season1673282SpecializedQuadProcess room_name=W48S6 target_room_name=W47S7 waypoints=W48S7 quad_type=tier3-6tower-dismantler targets=")
 
-// Game.io("launch -l Season1673282SpecializedQuadProcess room_name=W48S6 target_room_name=W47S9 waypoints=W47S9 quad_type=tier0-d360-dismantler targets=")
+// W46S9 tier0-d900
+// Game.io("launch -l Season1673282SpecializedQuadProcess room_name=W48S6 target_room_name=W46S9 waypoints=W47S9 quad_type=tier0-d900 targets=")
 export class Season1673282SpecializedQuadProcess implements Process, Procedural, MessageObserver {
   public readonly identifier: string
 

--- a/src/process/onetime/season_1673282_specialized_quad_process.ts
+++ b/src/process/onetime/season_1673282_specialized_quad_process.ts
@@ -112,6 +112,9 @@ export interface Season1673282SpecializedQuadProcessState extends ProcessState {
 // W46S9 tier3-6tower-dismantler
 // [Boost Needed]: XZHO2: 1200, XZH2O: 540, XGHO2: 2640, XLHO2: 720, XKHO2: 900
 // Game.io("launch -l Season1673282SpecializedQuadProcess room_name=W48S6 target_room_name=W49S5 waypoints=W48S5 quad_type=tier3-6tower-dismantler targets=")
+
+// W43S5 invader-core-attacker
+// Game.io("launch -l Season1673282SpecializedQuadProcess room_name=W48S6 target_room_name=W43S5 waypoints=W47S7 quad_type=invader-core-attacker targets=")
 export class Season1673282SpecializedQuadProcess implements Process, Procedural, MessageObserver {
   public readonly identifier: string
 

--- a/src/process/onetime/season_1673282_specialized_quad_process.ts
+++ b/src/process/onetime/season_1673282_specialized_quad_process.ts
@@ -111,7 +111,7 @@ export interface Season1673282SpecializedQuadProcessState extends ProcessState {
 
 // W46S9 tier3-6tower-dismantler
 // [Boost Needed]: XZHO2: 1200, XZH2O: 540, XGHO2: 2640, XLHO2: 720, XKHO2: 900
-// Game.io("launch -l Season1673282SpecializedQuadProcess room_name=W48S6 target_room_name=W46S9 waypoints=W47S9 quad_type=tier3-6tower-dismantler targets=")
+// Game.io("launch -l Season1673282SpecializedQuadProcess room_name=W48S6 target_room_name=W49S5 waypoints=W48S5 quad_type=tier3-6tower-dismantler targets=")
 export class Season1673282SpecializedQuadProcess implements Process, Procedural, MessageObserver {
   public readonly identifier: string
 

--- a/src/process/onetime/season_1673282_specialized_quad_process.ts
+++ b/src/process/onetime/season_1673282_specialized_quad_process.ts
@@ -115,6 +115,8 @@ export interface Season1673282SpecializedQuadProcessState extends ProcessState {
 
 // W43S5 invader-core-attacker
 // Game.io("launch -l Season1673282SpecializedQuadProcess room_name=W48S6 target_room_name=W43S5 waypoints=W47S7 quad_type=invader-core-attacker targets=")
+
+// Game.io("launch -l Season1673282SpecializedQuadProcess room_name=W48S6 target_room_name=W46S5 waypoints=W47S7,W46S7 quad_type=tier1-invader-core-lv1 targets=")
 export class Season1673282SpecializedQuadProcess implements Process, Procedural, MessageObserver {
   public readonly identifier: string
 

--- a/src/process/onetime/season_1673282_specialized_quad_process.ts
+++ b/src/process/onetime/season_1673282_specialized_quad_process.ts
@@ -102,6 +102,9 @@ export interface Season1673282SpecializedQuadProcessState extends ProcessState {
 // Game.io("launch -l Season1673282SpecializedQuadProcess room_name=W21S23 target_room_name=W25S22 waypoints=W20S23,W20S20,W25S20,W25S21 quad_type=tier0-d360-dismantler targets=")
 // tier0-d360-dismantler left
 // Game.io("launch -l Season1673282SpecializedQuadProcess room_name=W21S23 target_room_name=W25S22 waypoints=W20S23,W20S20,W23S20,W23S21,W24S21,W24S22 quad_type=tier0-d360-dismantler targets=")
+
+// W51S7 tier3-3tower-dismantler
+// Game.io("launch -l Season1673282SpecializedQuadProcess room_name=W54S7 target_room_name=W51S7 waypoints=W51S7 quad_type=tier3-3tower-dismantler targets=")
 export class Season1673282SpecializedQuadProcess implements Process, Procedural, MessageObserver {
   public readonly identifier: string
   private readonly codename: string

--- a/src/process/onetime/season_1673282_specialized_quad_process.ts
+++ b/src/process/onetime/season_1673282_specialized_quad_process.ts
@@ -109,8 +109,9 @@ export interface Season1673282SpecializedQuadProcessState extends ProcessState {
 // W47S7 tier3-6tower-dismantler
 // Game.io("launch -l Season1673282SpecializedQuadProcess room_name=W48S6 target_room_name=W47S7 waypoints=W48S7 quad_type=tier3-6tower-dismantler targets=")
 
-// W46S9 tier0-d900
-// Game.io("launch -l Season1673282SpecializedQuadProcess room_name=W48S6 target_room_name=W46S9 waypoints=W47S9 quad_type=tier0-d900 targets=")
+// W46S9 tier3-6tower-dismantler
+// [Boost Needed]: XZHO2: 1200, XZH2O: 540, XGHO2: 2640, XLHO2: 720, XKHO2: 900
+// Game.io("launch -l Season1673282SpecializedQuadProcess room_name=W48S6 target_room_name=W46S9 waypoints=W47S9 quad_type=tier3-6tower-dismantler targets=")
 export class Season1673282SpecializedQuadProcess implements Process, Procedural, MessageObserver {
   public readonly identifier: string
 
@@ -232,7 +233,7 @@ export class Season1673282SpecializedQuadProcess implements Process, Procedural,
       return "automatic rotation disabled"
     }
     const direction = parseInt(message, 10)
-    if (isNaN(direction) !== true && ([TOP, BOTTOM, RIGHT, LEFT] as number[]).includes(direction) === true) {
+    if (message.length <= 1 && isNaN(direction) !== true && ([TOP, BOTTOM, RIGHT, LEFT] as number[]).includes(direction) === true) {
       if (this.quadState == null) {
         if (this.creepNames.length > 0) {
           return "quad died"
@@ -265,7 +266,7 @@ export class Season1673282SpecializedQuadProcess implements Process, Procedural,
       return "Empty message"
     }
     this.manualOperations.targetIds.unshift(message as Id<AnyStructure | AnyCreep>)
-    return "ok"
+    return `target ${message} set`
   }
 
   public runOnTick(): void {

--- a/src/process/onetime/season_1673282_specialized_quad_spec.ts
+++ b/src/process/onetime/season_1673282_specialized_quad_spec.ts
@@ -31,6 +31,7 @@ export const quadTypes = [
   "tier3-2tower-attacker",
   "tier3-3tower-attacker",
   "tier3-3tower-dismantler",
+  "tier3-6tower-dismantler",
 ] as const
 export type QuadType = typeof quadTypes[number]
 
@@ -78,6 +79,7 @@ export class QuadSpec {
     case "tier3-4tower-1dismantler-rcl7":
     case "tier3-4tower-rcl7":
     case "tier3-3tower-dismantler":
+    case "tier3-6tower-dismantler":
       return [...tier3DismantlerFullBoosts]
     case "tier3-3tower-dismantler-attacker":
       return [...tier3DismantlerAttackerFullBoosts]
@@ -115,6 +117,7 @@ export class QuadSpec {
     case "tier3-2tower-attacker":
     case "tier3-3tower-attacker":
     case "tier3-3tower-dismantler":
+    case "tier3-6tower-dismantler":
       return 4
     }
   }
@@ -239,6 +242,12 @@ export class QuadSpec {
       } else {
         return tier33Tower2DismantlerDismantlerSpec
       }
+    case "tier3-6tower-dismantler":
+      if (creepInsufficiency <= 3) {
+        return tier36TowerDismantlerHealerSpec
+      } else {
+        return tier36TowerDismantlerDismantlerSpec
+      }
     }
   }
 
@@ -266,6 +275,7 @@ export class QuadSpec {
     case "tier3-4tower-rcl7":
     case "tier3-3tower-dismantler-attacker":
     case "tier3-3tower-dismantler":
+    case "tier3-6tower-dismantler":
       return false
     case "tier3-2tower-attacker":
     case "tier3-3tower-attacker":
@@ -822,10 +832,10 @@ const tier33TowerAttackerHealerSpec: CreepBodySpec = {
     RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK,
     RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK,
     RANGED_ATTACK, RANGED_ATTACK,
+    MOVE, MOVE, MOVE, MOVE, MOVE,
+    MOVE, MOVE, MOVE, MOVE, MOVE,
     HEAL, HEAL, HEAL, HEAL, HEAL,
     HEAL, HEAL,
-    MOVE, MOVE, MOVE, MOVE, MOVE,
-    MOVE, MOVE, MOVE, MOVE, MOVE,
   ]
 }
 
@@ -847,3 +857,37 @@ const tier33Tower2DismantlerDismantlerSpec: CreepBodySpec = {
   ]
 }
 const tier33Tower2DismantlerHealerSpec = { ...tier33TowerAttackerHealerSpec}
+
+// ---- tier3-6tower-dismantler ---- //
+const tier36TowerDismantlerDismantlerSpec: CreepBodySpec = {
+  roles: [CreepRole.Worker, CreepRole.Mover],
+  body: [
+    TOUGH, TOUGH, TOUGH, TOUGH, TOUGH,
+    TOUGH, TOUGH, TOUGH, TOUGH, TOUGH,
+    TOUGH, TOUGH, TOUGH, TOUGH, TOUGH,
+    TOUGH, TOUGH, TOUGH, TOUGH, TOUGH,
+    TOUGH, TOUGH,
+    WORK, WORK, WORK, WORK, WORK,
+    WORK, WORK, WORK, WORK, WORK,
+    WORK, WORK, WORK, WORK, WORK,
+    WORK, WORK, WORK,
+    MOVE, MOVE, MOVE, MOVE, MOVE,
+    MOVE, MOVE, MOVE, MOVE, MOVE,
+  ]
+}
+const tier36TowerDismantlerHealerSpec: CreepBodySpec = {
+  roles: [CreepRole.Worker, CreepRole.Mover],
+  body: [
+    TOUGH, TOUGH, TOUGH, TOUGH, TOUGH,
+    TOUGH, TOUGH, TOUGH, TOUGH, TOUGH,
+    TOUGH, TOUGH, TOUGH, TOUGH, TOUGH,
+    TOUGH, TOUGH, TOUGH, TOUGH, TOUGH,
+    TOUGH, TOUGH,
+    RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK,
+    RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK,
+    MOVE, MOVE, MOVE, MOVE, MOVE,
+    MOVE, MOVE, MOVE, MOVE, MOVE,
+    HEAL, HEAL, HEAL, HEAL, HEAL,
+    HEAL, HEAL, HEAL,
+  ]
+}

--- a/src/process/onetime/season_1673282_specialized_quad_spec.ts
+++ b/src/process/onetime/season_1673282_specialized_quad_spec.ts
@@ -20,6 +20,7 @@ export const quadTypes = [
   "tier0-d900",
   "tier0-swamp-attacker",
   "tier1-d750",
+  "tier1-invader-core-lv1",
   "no-defence-3tower",
   "tier3-d2000-dismantler-swamp",
   "tier3-3tower-full-ranged-attacker",
@@ -69,6 +70,8 @@ export class QuadSpec {
       return [...noBoosts]
     case "tier1-d750":
       return [...tier1D750Boosts]
+    case "tier1-invader-core-lv1":
+      return [...tier1AttackerBoosts]
     case "tier3-d2000-dismantler-swamp":
       return [...tier3DismantlerBoost1]
     case "no-defence-3tower":
@@ -98,6 +101,7 @@ export class QuadSpec {
     case "test-boosted-attacker":
       return 4
     case "invader-core-attacker":
+    case "tier1-invader-core-lv1":
       return 3
     case "tier0-2tower-drain-minimum":
     case "tier0-d100-attacker":
@@ -185,6 +189,12 @@ export class QuadSpec {
       }
     case "tier1-d750":
       return tier1D750HealerSpec
+    case "tier1-invader-core-lv1":
+      if (creepInsufficiency <= 1) {
+        return tier1InvaderCoreLv1HealerSpec
+      } else {
+        return tier1InvaderCoreLv1AttackerSpec
+      }
     case "tier3-d2000-dismantler-swamp":
       if (creepInsufficiency <= 1) {
         return tier3SwampDismantlerSpec
@@ -282,6 +292,7 @@ export class QuadSpec {
     case "tier3-3tower-dismantler":
     case "tier3-6tower-dismantler":
     case "tier0-d900":
+    case "tier1-invader-core-lv1":
       return false
     case "tier3-2tower-attacker":
     case "tier3-3tower-attacker":
@@ -483,6 +494,49 @@ const tier1D750Boosts: MineralBoostConstant[] = [
   RESOURCE_ZYNTHIUM_OXIDE,
   RESOURCE_LEMERGIUM_OXIDE,
   RESOURCE_CATALYZED_KEANIUM_ALKALIDE,
+]
+
+// ---- tier1-invader-core-lv1 ---- //
+const tier1InvaderCoreLv1AttackerSpec: CreepBodySpec = {
+  roles: [CreepRole.Attacker, CreepRole.Mover],
+  body: [
+    ATTACK, ATTACK, ATTACK, ATTACK, ATTACK,
+    ATTACK, ATTACK, ATTACK, ATTACK, ATTACK,
+    ATTACK, ATTACK, ATTACK, ATTACK, ATTACK,
+    MOVE, MOVE, MOVE, MOVE, MOVE,
+    ATTACK, ATTACK, ATTACK, ATTACK, ATTACK,
+    ATTACK, ATTACK, ATTACK, ATTACK, ATTACK,
+    MOVE, MOVE, MOVE, MOVE, MOVE,
+    ATTACK, ATTACK, ATTACK, ATTACK, ATTACK,
+    ATTACK, ATTACK, ATTACK,
+    MOVE, MOVE, MOVE, MOVE, MOVE,
+    MOVE, MOVE,
+  ]
+}
+const tier1InvaderCoreLv1HealerSpec: CreepBodySpec = {
+  roles: [CreepRole.RangedAttacker, CreepRole.Healer, CreepRole.Mover],
+  body: [
+    RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK,
+    RANGED_ATTACK, RANGED_ATTACK,
+    MOVE, MOVE, MOVE, MOVE, MOVE,
+    MOVE, MOVE, MOVE, MOVE, MOVE,
+    MOVE, MOVE, MOVE, MOVE, MOVE,
+    MOVE, MOVE,
+    HEAL, HEAL, HEAL, HEAL, HEAL,
+    HEAL, HEAL, HEAL, HEAL, HEAL,
+    HEAL, HEAL, HEAL, HEAL, HEAL,
+    HEAL, HEAL, HEAL, HEAL, HEAL,
+    HEAL, HEAL, HEAL, HEAL, HEAL,
+    HEAL,
+  ]
+}
+
+// ---- tier1 attacker boosts ---- //
+const tier1AttackerBoosts: MineralBoostConstant[] = [
+  RESOURCE_ZYNTHIUM_OXIDE,
+  RESOURCE_UTRIUM_HYDRIDE,
+  RESOURCE_LEMERGIUM_OXIDE,
+  RESOURCE_KEANIUM_OXIDE,
 ]
 
 // ---- no-defence-3tower ---- //

--- a/src/process/onetime/season_1673282_specialized_quad_spec.ts
+++ b/src/process/onetime/season_1673282_specialized_quad_spec.ts
@@ -17,6 +17,7 @@ export const quadTypes = [
   "tier0-d450-rcl7",
   "tier0-d360-dismantler",
   "tier0-d360-dismantler-rcl7",
+  "tier0-d900",
   "tier0-swamp-attacker",
   "tier1-d750",
   "no-defence-3tower",
@@ -63,6 +64,7 @@ export class QuadSpec {
     case "tier0-d450-rcl7":
     case "tier0-d360-dismantler":
     case "tier0-d360-dismantler-rcl7":
+    case "tier0-d900":
     case "tier0-swamp-attacker":
       return [...noBoosts]
     case "tier1-d750":
@@ -103,6 +105,7 @@ export class QuadSpec {
     case "tier0-d450-rcl7":
     case "tier0-d360-dismantler":
     case "tier0-d360-dismantler-rcl7":
+    case "tier0-d900":
     case "tier0-swamp-attacker":
     case "tier3-d2000-dismantler-swamp":
     case "tier1-d750":
@@ -160,6 +163,8 @@ export class QuadSpec {
       return tire0h10HealerSpec
     case "tier0-d450-rcl7":
       return tire0h10HealerRCL7Spec
+    case "tier0-d900":
+      return tire0h20HealerSpec
     case "tier0-swamp-attacker":
       if (creepInsufficiency <= 1) {
         return tier0SwampAttackerAttackerSpec
@@ -276,6 +281,7 @@ export class QuadSpec {
     case "tier3-3tower-dismantler-attacker":
     case "tier3-3tower-dismantler":
     case "tier3-6tower-dismantler":
+    case "tier0-d900":
       return false
     case "tier3-2tower-attacker":
     case "tier3-3tower-attacker":
@@ -408,6 +414,20 @@ const tire0DismantlerSpec: CreepBodySpec = {
     WORK, MOVE, WORK, MOVE, WORK, MOVE, WORK, MOVE, WORK, MOVE,
     WORK, MOVE, WORK, MOVE, WORK, MOVE, WORK, MOVE, WORK, MOVE,
     WORK, MOVE, WORK, MOVE, WORK, MOVE, WORK, MOVE, WORK, MOVE,
+    MOVE, MOVE, MOVE, MOVE, MOVE,
+  ]
+}
+
+// ---- tier0-d900 ---- //
+const tire0h20HealerSpec: CreepBodySpec = {
+  roles: [CreepRole.RangedAttacker, CreepRole.Healer, CreepRole.Mover],
+  body: [
+    RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK,
+    HEAL, HEAL, HEAL, HEAL, HEAL,
+    HEAL, MOVE, HEAL, MOVE, HEAL, MOVE, HEAL, MOVE, HEAL, MOVE,
+    HEAL, MOVE, HEAL, MOVE, HEAL, MOVE, HEAL, MOVE, HEAL, MOVE,
+    HEAL, MOVE, HEAL, MOVE, HEAL, MOVE, HEAL, MOVE, HEAL, MOVE,
+    MOVE, MOVE, MOVE, MOVE, MOVE,
     MOVE, MOVE, MOVE, MOVE, MOVE,
   ]
 }

--- a/src/process/onetime/season_1673282_specialized_quad_spec.ts
+++ b/src/process/onetime/season_1673282_specialized_quad_spec.ts
@@ -30,6 +30,7 @@ export const quadTypes = [
   "tier3-3tower-dismantler-attacker",
   "tier3-2tower-attacker",
   "tier3-3tower-attacker",
+  "tier3-3tower-dismantler",
 ] as const
 export type QuadType = typeof quadTypes[number]
 
@@ -76,6 +77,7 @@ export class QuadSpec {
     case "tier3-4tower-1dismantler":
     case "tier3-4tower-1dismantler-rcl7":
     case "tier3-4tower-rcl7":
+    case "tier3-3tower-dismantler":
       return [...tier3DismantlerFullBoosts]
     case "tier3-3tower-dismantler-attacker":
       return [...tier3DismantlerAttackerFullBoosts]
@@ -112,6 +114,7 @@ export class QuadSpec {
     case "tier3-3tower-dismantler-attacker":
     case "tier3-2tower-attacker":
     case "tier3-3tower-attacker":
+    case "tier3-3tower-dismantler":
       return 4
     }
   }
@@ -230,6 +233,12 @@ export class QuadSpec {
       } else {
         return tier33TowerAttackerHealerSpec
       }
+    case "tier3-3tower-dismantler":
+      if (creepInsufficiency <= 2) {
+        return tier33Tower2DismantlerHealerSpec
+      } else {
+        return tier33Tower2DismantlerDismantlerSpec
+      }
     }
   }
 
@@ -256,6 +265,7 @@ export class QuadSpec {
     case "tier3-4tower-1dismantler-rcl7":
     case "tier3-4tower-rcl7":
     case "tier3-3tower-dismantler-attacker":
+    case "tier3-3tower-dismantler":
       return false
     case "tier3-2tower-attacker":
     case "tier3-3tower-attacker":
@@ -818,3 +828,22 @@ const tier33TowerAttackerHealerSpec: CreepBodySpec = {
     MOVE, MOVE, MOVE, MOVE, MOVE,
   ]
 }
+
+// ---- tier3-3tower-dismantler ---- //
+const tier33Tower2DismantlerDismantlerSpec: CreepBodySpec = {
+  roles: [CreepRole.Worker, CreepRole.Mover],
+  body: [
+    TOUGH, TOUGH, TOUGH, TOUGH, TOUGH,
+    TOUGH, TOUGH, TOUGH, TOUGH, TOUGH,
+    TOUGH,
+    WORK, WORK, WORK, WORK, WORK,
+    WORK, WORK, WORK, WORK, WORK,
+    WORK, WORK, WORK, WORK, WORK,
+    WORK, WORK, WORK, WORK, WORK,
+    WORK, WORK, WORK, WORK, WORK,
+    WORK, WORK, WORK, WORK,
+    MOVE, MOVE, MOVE, MOVE, MOVE,
+    MOVE, MOVE, MOVE, MOVE, MOVE,
+  ]
+}
+const tier33Tower2DismantlerHealerSpec = { ...tier33TowerAttackerHealerSpec}

--- a/src/process/onetime/season_1673282_specialized_quad_spec.ts
+++ b/src/process/onetime/season_1673282_specialized_quad_spec.ts
@@ -34,6 +34,7 @@ export const quadTypes = [
   "tier3-3tower-attacker",
   "tier3-3tower-dismantler",
   "tier3-6tower-dismantler",
+  "tier3-6tower-tank",
 ] as const
 export type QuadType = typeof quadTypes[number]
 
@@ -91,6 +92,8 @@ export class QuadSpec {
     case "tier3-2tower-attacker":
     case "tier3-3tower-attacker":
       return [...tier3AttackerBoosts]
+    case "tier3-6tower-tank":
+      return [...tier3HealBoosts]
     }
   }
 
@@ -102,6 +105,7 @@ export class QuadSpec {
       return 4
     case "invader-core-attacker":
     case "tier1-invader-core-lv1":
+    case "tier3-6tower-tank":
       return 3
     case "tier0-2tower-drain-minimum":
     case "tier0-d100-attacker":
@@ -263,6 +267,8 @@ export class QuadSpec {
       } else {
         return tier36TowerDismantlerDismantlerSpec
       }
+    case "tier3-6tower-tank":
+      return tier36TowerTankHealerSpec
     }
   }
 
@@ -293,6 +299,7 @@ export class QuadSpec {
     case "tier3-6tower-dismantler":
     case "tier0-d900":
     case "tier1-invader-core-lv1":
+    case "tier3-6tower-tank":
       return false
     case "tier3-2tower-attacker":
     case "tier3-3tower-attacker":
@@ -965,3 +972,22 @@ const tier36TowerDismantlerHealerSpec: CreepBodySpec = {
     HEAL, HEAL, HEAL,
   ]
 }
+
+// ---- tier3-6tower-tank ---- //
+const tier36TowerTankHealerSpec: CreepBodySpec = {
+  roles: [CreepRole.Healer, CreepRole.RangedAttacker, CreepRole.Mover],
+  body: [
+    TOUGH, TOUGH, TOUGH, TOUGH, TOUGH,
+    RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK, RANGED_ATTACK,
+    MOVE, MOVE, MOVE, MOVE, MOVE,
+    MOVE, MOVE, MOVE, MOVE, MOVE,
+    MOVE, MOVE, MOVE, MOVE, MOVE,
+    MOVE, MOVE,
+    HEAL, HEAL, HEAL, HEAL, HEAL,
+    HEAL, HEAL,
+  ]
+}
+
+const tier3HealBoosts: MineralBoostConstant[] = [
+  RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE,
+]

--- a/src/process/onetime/season_1838855_distributor_process.ts
+++ b/src/process/onetime/season_1838855_distributor_process.ts
@@ -300,15 +300,9 @@ export class Season1838855DistributorProcess implements Process, Procedural {
   }
 
   private transferEnergyTask(creep: Creep, storage: StructureStorage, terminal: StructureTerminal, link: StructureLink | null, resources: OwnedRoomResource): CreepTask | null {
-    const energySources = ((): [EnergyStore, EnergyStore] | null => {
+    const energySources = ((): [EnergyStore, EnergyStore] => {
       const terminalEnergyAmount = terminal.store.getUsedCapacity(RESOURCE_ENERGY)
-      const storageEnergyAmount = storage.store.getUsedCapacity(RESOURCE_ENERGY)
       const minimumEnergy = 40000
-      if (terminalEnergyAmount < minimumEnergy && storageEnergyAmount < minimumEnergy) {
-        if (creep.store.getUsedCapacity() <= 0) {
-          return null
-        }
-      }
       const needEnergy = resources.roomInfo.resourceInsufficiencies[RESOURCE_ENERGY] != null
       if (needEnergy === true && terminalEnergyAmount >= minimumEnergy) {
         return [terminal, storage]
@@ -332,17 +326,17 @@ export class Season1838855DistributorProcess implements Process, Procedural {
       return RunApiTask.create(TransferEnergyApiWrapper.create(energyStore))
     }
 
-    if (link == null || link.store.getFreeCapacity(RESOURCE_ENERGY) <= 0) {
-      const energyAmount = storage.store.getUsedCapacity(RESOURCE_ENERGY) + terminal.store.getUsedCapacity(RESOURCE_ENERGY)
-      if (energyAmount > 700000 && energySource instanceof StructureTerminal) {
-        processLog(this, `Has enough energy ${roomLink(this.parentRoomName)}`)
-        return null
-      }
-    }
-    if ((energySource instanceof StructureStorage) && energySource.store.getUsedCapacity(RESOURCE_ENERGY) < 50000) {
-      processLog(this, `Not enough energy in ${energySource} ${roomLink(this.parentRoomName)}`)
-      return null
-    }
+    // if (link == null || link.store.getFreeCapacity(RESOURCE_ENERGY) <= 0) {
+    //   const energyAmount = storage.store.getUsedCapacity(RESOURCE_ENERGY) + terminal.store.getUsedCapacity(RESOURCE_ENERGY)
+    //   if (energyAmount > 700000 && energySource instanceof StructureTerminal) {
+    //     processLog(this, `Has enough energy ${roomLink(this.parentRoomName)}`)
+    //     return null
+    //   }
+    // }
+    // if ((energySource instanceof StructureStorage) && energySource.store.getUsedCapacity(RESOURCE_ENERGY) < 50000) {
+    //   processLog(this, `Not enough energy in ${energySource} ${roomLink(this.parentRoomName)}`)
+    //   return null
+    // }
     return RunApiTask.create(WithdrawResourceApiWrapper.create(energySource, RESOURCE_ENERGY))
   }
 

--- a/src/process/onetime/season_487837_attack_invader_core_process.ts
+++ b/src/process/onetime/season_487837_attack_invader_core_process.ts
@@ -58,18 +58,6 @@ export class Season487837AttackInvaderCoreProcess implements Process, Procedural
 
   public runOnTick(): void {
     const invadedRoomNames: RoomName[] = []
-    // const remoteRoomNamesToDefend: {parent: RoomName, target: RoomName}[] = OperatingSystem.os.listAllProcesses()
-    //   .flatMap(processInfo => {
-    //     const process = processInfo.process
-    //     if (!(process instanceof RemoteRoomHarvesterTask)) {
-    //       return []
-    //     }
-    //     return {
-    //       parent: process.roomName,
-    //       target: process.targetRoomName,
-    //     }
-    //   })
-
     remoteRoomNamesToDefend.forEach((targetRoomNames, parentRoomName) => {
       invadedRoomNames.push(...this.runOnRoom(parentRoomName, targetRoomNames))
     })

--- a/src/process/onetime/season_487837_attack_invader_core_room_names.ts
+++ b/src/process/onetime/season_487837_attack_invader_core_room_names.ts
@@ -1,36 +1,37 @@
 import { PrimitiveLogger } from "os/infrastructure/primitive_logger"
 import { Environment } from "utility/environment"
 import { RoomName } from "utility/room_name"
+import { ValuedArrayMap } from "utility/valued_collection"
 
-export const remoteRoomNamesToDefend = ((): Map<RoomName, RoomName[]> => {
+export const remoteRoomNamesToDefend = ((): ValuedArrayMap<RoomName, RoomName> => {
   switch (Environment.world) {
   case "persistent world":
     switch (Environment.shard) {
     case "shard0":
     case "shard1":
-      return new Map<RoomName, RoomName[]>([
+      return new ValuedArrayMap<RoomName, RoomName>([
       ])
     case "shard2":
-      return new Map<RoomName, RoomName[]>([
+      return new ValuedArrayMap<RoomName, RoomName>([
         ["W57S27", ["W57S26", "W57S28"]],
         ["W52S25", ["W52S26"]],
         ["W53S36", ["W52S36"]],
       ])
     case "shard3":
-      return new Map<RoomName, RoomName[]>([
+      return new ValuedArrayMap<RoomName, RoomName>([
       ])
     default:
       if ((Game.time % 19) === 11) {
         PrimitiveLogger.programError(`remoteRoomNamesToDefend unknown shard name ${Environment.shard} in ${Environment.world}`)
       }
-      return new Map<RoomName, RoomName[]>([
+      return new ValuedArrayMap<RoomName, RoomName>([
       ])
     }
   case "simulation":
-    return new Map<RoomName, RoomName[]>([
+    return new ValuedArrayMap<RoomName, RoomName>([
     ])
   case "season 3":
-    return new Map<RoomName, RoomName[]>([
+    return new ValuedArrayMap<RoomName, RoomName>([
       ["W27S26", ["W27S27", "W27S25"]], // "W28S26"
       ["W24S29", ["W25S29", "W23S29", "W24S28"]],
       ["W14S28", ["W15S28", "W14S29", "W14S27"]],

--- a/src/process/onetime/season_487837_attack_invader_core_room_names.ts
+++ b/src/process/onetime/season_487837_attack_invader_core_room_names.ts
@@ -27,9 +27,6 @@ export const remoteRoomNamesToDefend = ((): ValuedArrayMap<RoomName, RoomName> =
       return new ValuedArrayMap<RoomName, RoomName>([
       ])
     }
-  case "simulation":
-    return new ValuedArrayMap<RoomName, RoomName>([
-    ])
   case "season 3":
     return new ValuedArrayMap<RoomName, RoomName>([
       ["W27S26", ["W27S27", "W27S25"]], // "W28S26"
@@ -47,6 +44,11 @@ export const remoteRoomNamesToDefend = ((): ValuedArrayMap<RoomName, RoomName> =
       ["W15S8", ["W16S8", "W15S9", "W14S8"]],
       ["W26S9", ["W26S8"]],
       ["W5S21", ["W6S21", "W5S22", "W4S21"]],
+    ])
+  case "simulation":
+  case "botarena":
+  default:
+    return new ValuedArrayMap<RoomName, RoomName>([
     ])
   }
 })()

--- a/src/process/onetime/world_35440623_downgrade_controller_process.ts
+++ b/src/process/onetime/world_35440623_downgrade_controller_process.ts
@@ -1,0 +1,131 @@
+import { Procedural } from "process/procedural"
+import { Process, ProcessId } from "process/process"
+import { RoomName } from "utility/room_name"
+import { roomLink } from "utility/log"
+import { ProcessState } from "process/process_state"
+import { CreepRole } from "prototype/creep_role"
+import { generateCodename } from "utility/unique_id"
+import { World } from "world_info/world_info"
+import { CreepSpawnRequestPriority } from "world_info/resource_pool/creep_specs"
+import { CreepTask } from "v5_object_task/creep_task/creep_task"
+import { MoveToRoomTask } from "v5_object_task/creep_task/meta_task/move_to_room_task"
+import { CreepPoolAssignPriority } from "world_info/resource_pool/creep_resource_pool"
+import { MoveToTargetTask } from "v5_object_task/creep_task/combined_task/move_to_target_task"
+import { Timestamp } from "utility/timestamp"
+import { RoomResources } from "room_resource/room_resources"
+import { PrimitiveLogger } from "os/infrastructure/primitive_logger"
+import { CreepBody } from "utility/creep_body"
+import { AttackControllerApiWrapper } from "v5_object_task/creep_task/api_wrapper/attack_controller_api_wrapper"
+
+export interface World35440623DowngradeControllerProcessState extends ProcessState {
+  /** parent room name */
+  p: RoomName
+
+  targetRoomNames: RoomName[]
+  currentTargetRoomNames: RoomName[]
+  lastSpawnTime: Timestamp
+}
+
+// Game.io("launch -l World35440623DowngradeControllerProcess room_name=W48S6 target_room_names=W49S6,W49S7,W49S6,W48S5,W48S4,W48S7,W47S7,W47S6,W47S9")
+export class World35440623DowngradeControllerProcess implements Process, Procedural {
+  public readonly identifier: string
+  private readonly codename: string
+
+  private constructor(
+    public readonly launchTime: number,
+    public readonly processId: ProcessId,
+    public readonly parentRoomName: RoomName,
+    private readonly targetRoomNames: RoomName[],
+    private readonly currentTargetRoomNames: RoomName[],
+    private lastSpawnTime: Timestamp,
+  ) {
+    this.identifier = `${this.constructor.name}_${this.launchTime}_${this.parentRoomName}_${this.targetRoomNames}`
+    this.codename = generateCodename(this.identifier, this.launchTime)
+  }
+
+  public encode(): World35440623DowngradeControllerProcessState {
+    return {
+      t: "World35440623DowngradeControllerProcess",
+      l: this.launchTime,
+      i: this.processId,
+      p: this.parentRoomName,
+      targetRoomNames: this.targetRoomNames,
+      currentTargetRoomNames: this.currentTargetRoomNames,
+      lastSpawnTime: this.lastSpawnTime,
+    }
+  }
+
+  public static decode(state: World35440623DowngradeControllerProcessState): World35440623DowngradeControllerProcess {
+    return new World35440623DowngradeControllerProcess(state.l, state.i, state.p, state.targetRoomNames, state.currentTargetRoomNames, state.lastSpawnTime)
+  }
+
+  public static create(processId: ProcessId, parentRoomName: RoomName, targetRoomNames: RoomName[]): World35440623DowngradeControllerProcess {
+    return new World35440623DowngradeControllerProcess(Game.time, processId, parentRoomName, targetRoomNames, [...targetRoomNames], 0)
+  }
+
+  public processShortDescription(): string {
+    return this.targetRoomNames.map(roomName => roomLink(roomName)).join(",")
+  }
+
+  public runOnTick(): void {
+    const resources = RoomResources.getOwnedRoomResource(this.parentRoomName)
+    if (resources == null) {
+      PrimitiveLogger.fatal(`${roomLink(this.parentRoomName)} lost`)
+      return
+    }
+
+    const creepCount = World.resourcePools.countCreeps(this.parentRoomName, this.identifier, () => true)
+    const attackControllerCooldownTime = 1000
+    if (creepCount < 1 && (Game.time - attackControllerCooldownTime - 50) > this.lastSpawnTime) {
+      const energyAmount = (resources.activeStructures.terminal?.store.getUsedCapacity(RESOURCE_ENERGY) ?? 0) + (resources.activeStructures.storage?.store.getUsedCapacity(RESOURCE_ENERGY) ?? 0)
+      if (energyAmount > 70000) {
+        this.spawnDowngrader(resources.room.energyCapacityAvailable)
+      }
+    }
+
+    World.resourcePools.assignTasks(
+      this.parentRoomName,
+      this.identifier,
+      CreepPoolAssignPriority.Low,
+      creep => this.newTaskFor(creep),
+      () => true,
+    )
+  }
+
+  private spawnDowngrader(energyCapacity: number): void {
+    World.resourcePools.addSpawnCreepRequest(this.parentRoomName, {
+      priority: CreepSpawnRequestPriority.Low,
+      numberOfCreeps: 1,
+      codename: this.codename,
+      roles: [CreepRole.Claimer, CreepRole.Mover],
+      body: CreepBody.create([], [CLAIM, MOVE], energyCapacity, 20),
+      initialTask: null,
+      taskIdentifier: this.identifier,
+      parentRoomName: null,
+    })
+  }
+
+  private newTaskFor(creep: Creep): CreepTask | null {
+    const controller = creep.room.controller
+    if (controller == null || controller.owner == null || controller.my === true || (controller.upgradeBlocked ?? 0) > 0) {
+      const moveToNextRoomTask = this.moveToNextRoomTask()
+      if (moveToNextRoomTask == null) {
+        creep.say("finished")
+      }
+      return moveToNextRoomTask
+    }
+    return MoveToTargetTask.create(AttackControllerApiWrapper.create(controller), {ignoreSwamp: false, reusePath: 0})
+  }
+
+  private moveToNextRoomTask(): CreepTask | null {
+    const nextRoomName = this.nextRoomName()
+    if (nextRoomName == null) {
+      return null
+    }
+    return MoveToRoomTask.create(nextRoomName, [])
+  }
+
+  private nextRoomName(): RoomName | null {
+    return this.currentTargetRoomNames.shift() ?? null
+  }
+}

--- a/src/process/onetime/world_35440623_downgrade_controller_process.ts
+++ b/src/process/onetime/world_35440623_downgrade_controller_process.ts
@@ -18,6 +18,7 @@ import { CreepBody } from "utility/creep_body"
 import { AttackControllerApiWrapper } from "v5_object_task/creep_task/api_wrapper/attack_controller_api_wrapper"
 
 const attackControllerCooldownTime = 1000
+const attackControllerInterval = attackControllerCooldownTime + 100
 
 export interface World35440623DowngradeControllerProcessState extends ProcessState {
   /** parent room name */
@@ -66,7 +67,7 @@ export class World35440623DowngradeControllerProcess implements Process, Procedu
   }
 
   public processShortDescription(): string {
-    const ticksToSpawn = Math.max(attackControllerCooldownTime - (Game.time - this.lastSpawnTime), 0)
+    const ticksToSpawn = Math.max(attackControllerInterval - (Game.time - this.lastSpawnTime), 0)
     return `${ticksToSpawn} to go, ${this.targetRoomNames.map(roomName => roomLink(roomName)).join(",")}`
   }
 
@@ -78,7 +79,7 @@ export class World35440623DowngradeControllerProcess implements Process, Procedu
     }
 
     const creepCount = World.resourcePools.countCreeps(this.parentRoomName, this.identifier, () => true)
-    if (creepCount < 1 && (Game.time - attackControllerCooldownTime) > this.lastSpawnTime) {
+    if (creepCount < 1 && (Game.time - attackControllerInterval) > this.lastSpawnTime) {
       const energyAmount = (resources.activeStructures.terminal?.store.getUsedCapacity(RESOURCE_ENERGY) ?? 0) + (resources.activeStructures.storage?.store.getUsedCapacity(RESOURCE_ENERGY) ?? 0)
       if (energyAmount > 70000) {
         this.currentTargetRoomNames = [...this.targetRoomNames]

--- a/src/process/process/inter_room_resource_management_process.ts
+++ b/src/process/process/inter_room_resource_management_process.ts
@@ -88,20 +88,8 @@ class CompoundManager {
 
 class ResourceTransferer {
   private readonly ownedRoomResources = new Map<RoomName, OwnedRoomResource>()
-  // private readonly resourceStores = new ValuedArrayMap<ResourceConstant, RoomName>()
 
   public constructor() {
-    // const addResourceStore = (store: StoreDefinition, roomName: RoomName) => {
-    //   const resourceTypes = Object.keys(store) as ResourceConstant[]
-    //   resourceTypes.forEach(resourceType => {
-    //     const roomNames = this.resourceStores.getValueFor(resourceType)
-    //     if (roomNames.includes(roomName) === true) {
-    //       return
-    //     }
-    //     roomNames.push(roomName)
-    //   })
-    // }
-
     RoomResources.getOwnedRoomResources().forEach(resources => {
       const terminal = resources.activeStructures.terminal
       const storage = resources.activeStructures.storage
@@ -154,11 +142,6 @@ class ResourceTransferer {
           storage: storageFreeCapacity,
         }
       })
-
-      // if (storageSpace === "empty space") {
-      //   addResourceStore(terminal.store, resources.room.name)
-      //   addResourceStore(storage.store, resources.room.name)
-      // }
     })
   }
 

--- a/src/process/process/inter_room_resource_management_process.ts
+++ b/src/process/process/inter_room_resource_management_process.ts
@@ -78,6 +78,11 @@ const requiredCompounds = new Map<ResourceConstant, number>([
   [RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE, 10000],
   [RESOURCE_CATALYZED_GHODIUM_ALKALIDE, 10000],
 ])
+const excludedResourceTypes: ResourceConstant[] = [
+  RESOURCE_ENERGY,
+  RESOURCE_POWER,
+  RESOURCE_OPS,
+]
 
 class CompoundManager {
   public run(): string[] {
@@ -188,7 +193,7 @@ class ResourceTransferer {
       if (disableResourceTransfer !== true) {
         const excessResource = ((): { resourceType: ResourceConstant, sendAmount: number } | null => {
           for (const resourceType of resources.sortedResourceTypes) {
-            if (resourceType === RESOURCE_ENERGY) {
+            if (excludedResourceTypes.includes(resourceType) === true) {
               continue
             }
             const requiredAmount = requiredCompounds.get(resourceType) ?? 0

--- a/src/process/process/inter_room_resource_management_process.ts
+++ b/src/process/process/inter_room_resource_management_process.ts
@@ -174,7 +174,7 @@ class ResourceTransferer {
 
       const terminalEnergyAmount = resources.terminal.store.getUsedCapacity(RESOURCE_ENERGY)
       const storageEnergyAmount = resources.storage.store.getUsedCapacity(RESOURCE_ENERGY)
-      if (terminalEnergyAmount < 50000 || storageEnergyAmount < 50000) {
+      if (terminalEnergyAmount < 50000 || storageEnergyAmount < 50000 || (terminalEnergyAmount + storageEnergyAmount) < 200000) {
         return
       }
 

--- a/src/process/process/inter_room_resource_management_process.ts
+++ b/src/process/process/inter_room_resource_management_process.ts
@@ -5,7 +5,6 @@ import { ProcessState } from "../process_state"
 import { RoomResources } from "room_resource/room_resources"
 import { RoomName } from "utility/room_name"
 import { OwnedRoomInfo } from "room_resource/room_info"
-import { ValuedArrayMap } from "utility/valued_collection"
 import { processLog } from "process/process_log"
 import { PrimitiveLogger } from "os/infrastructure/primitive_logger"
 
@@ -54,7 +53,7 @@ export class InterRoomResourceManagementProcess implements Process, Procedural {
   }
 }
 
-type StorageSpace = "full" | "almost full" | "empty space"
+type StorageSpace = "full" | "empty space"
 type OwnedRoomResource = {
   readonly storageSpace: StorageSpace
   readonly terminal: StructureTerminal
@@ -70,7 +69,7 @@ type OwnedRoomResource = {
   },
 }
 
-const requiredEmptySpace = 30000
+const terminalRequiredEmptySpace = 30000
 const transactionCostRound = 10000
 const requiredCompounds = new Map<ResourceConstant, number>([
   [RESOURCE_CATALYZED_UTRIUM_ACID, 10000],
@@ -89,19 +88,19 @@ class CompoundManager {
 
 class ResourceTransferer {
   private readonly ownedRoomResources = new Map<RoomName, OwnedRoomResource>()
-  private readonly resourceStores = new ValuedArrayMap<ResourceConstant, RoomName>()
+  // private readonly resourceStores = new ValuedArrayMap<ResourceConstant, RoomName>()
 
   public constructor() {
-    const addResourceStore = (store: StoreDefinition, roomName: RoomName) => {
-      const resourceTypes = Object.keys(store) as ResourceConstant[]
-      resourceTypes.forEach(resourceType => {
-        const roomNames = this.resourceStores.getValueFor(resourceType)
-        if (roomNames.includes(roomName) === true) {
-          return
-        }
-        roomNames.push(roomName)
-      })
-    }
+    // const addResourceStore = (store: StoreDefinition, roomName: RoomName) => {
+    //   const resourceTypes = Object.keys(store) as ResourceConstant[]
+    //   resourceTypes.forEach(resourceType => {
+    //     const roomNames = this.resourceStores.getValueFor(resourceType)
+    //     if (roomNames.includes(roomName) === true) {
+    //       return
+    //     }
+    //     roomNames.push(roomName)
+    //   })
+    // }
 
     RoomResources.getOwnedRoomResources().forEach(resources => {
       const terminal = resources.activeStructures.terminal
@@ -113,10 +112,11 @@ class ResourceTransferer {
         return
       }
 
-      const terminalFreeCapacity = terminal.store.getFreeCapacity()
+      const margin = 1000
+      const terminalFreeCapacity = Math.max(terminal.store.getFreeCapacity() - terminalRequiredEmptySpace - margin, 0)
       const storageFreeCapacity = storage.store.getFreeCapacity()
       const storageSpace = ((): StorageSpace => {
-        if (terminalFreeCapacity < requiredEmptySpace || storageFreeCapacity < 100000) {
+        if (terminalFreeCapacity <= 0 || storageFreeCapacity < 100000) {
           return "full"
         }
         if ((storageFreeCapacity + storage.store.getUsedCapacity(RESOURCE_ENERGY)) < 300000) {
@@ -155,10 +155,10 @@ class ResourceTransferer {
         }
       })
 
-      if (storageSpace === "empty space") {
-        addResourceStore(terminal.store, resources.room.name)
-        addResourceStore(storage.store, resources.room.name)
-      }
+      // if (storageSpace === "empty space") {
+      //   addResourceStore(terminal.store, resources.room.name)
+      //   addResourceStore(storage.store, resources.room.name)
+      // }
     })
   }
 
@@ -176,11 +176,16 @@ class ResourceTransferer {
         return
       }
 
-      const energyAmount = resources.terminal.store.getUsedCapacity(RESOURCE_ENERGY)
-      if (energyAmount > 100000 && resources.roomInfo.resourceInsufficiencies[RESOURCE_ENERGY] == null) {
+      const terminalEnergyAmount = resources.terminal.store.getUsedCapacity(RESOURCE_ENERGY)
+      const storageEnergyAmount = resources.storage.store.getUsedCapacity(RESOURCE_ENERGY)
+      if (terminalEnergyAmount < 50000 || storageEnergyAmount < 50000) {
+        return
+      }
+
+      if (terminalEnergyAmount > 100000 && resources.roomInfo.resourceInsufficiencies[RESOURCE_ENERGY] == null) {
         const target = this.resourceInsufficientTarget(roomName, RESOURCE_ENERGY)
         if (target != null) {
-          const sendAmount = Math.min(Math.ceil((energyAmount - 50000) / 2), target.maxAmount)
+          const sendAmount = Math.min(Math.ceil((terminalEnergyAmount - 50000) / 2), target.maxAmount)
           const log = this.send(resources, RESOURCE_ENERGY, sendAmount, target.resources)
           if (log != null) {
             logs.push(log)
@@ -189,38 +194,38 @@ class ResourceTransferer {
         }
       }
 
-      // const excessResource = ((): { resourceType: ResourceConstant, sendAmount: number } | null => {
-      //   for (const resourceType of resources.sortedResourceTypes) {
-      //     if (resourceType === RESOURCE_ENERGY) {
-      //       continue
-      //     }
-      //     const requiredAmount = requiredCompounds.get(resourceType) ?? 0
-      //     const sendAmount = Math.max(resources.terminal.store.getUsedCapacity(resourceType) - requiredAmount, 0)
-      //     if (sendAmount <= 0) {
-      //       continue
-      //     }
-      //     return {
-      //       resourceType,
-      //       sendAmount,
-      //     }
-      //   }
-      //   return null
-      // })()
+      const excessResource = ((): { resourceType: ResourceConstant, sendAmount: number } | null => {
+        for (const resourceType of resources.sortedResourceTypes) {
+          if (resourceType === RESOURCE_ENERGY) {
+            continue
+          }
+          const requiredAmount = requiredCompounds.get(resourceType) ?? 0
+          const sendAmount = Math.max(resources.terminal.store.getUsedCapacity(resourceType) - requiredAmount, 0)
+          if (sendAmount <= 0) {
+            continue
+          }
+          return {
+            resourceType,
+            sendAmount,
+          }
+        }
+        return null
+      })()
 
-      // if (excessResource != null) {
-      //   const target = this.resourceInsufficientTarget(roomName, excessResource.resourceType) ?? this.freeSpaceRoom(roomName, excessResource.resourceType)
-      //   if (target != null) {
-      //     const energyAmount = resources.terminal.store.getUsedCapacity(RESOURCE_ENERGY)
-      //     const sendAmount = Math.min(excessResource.sendAmount, target.maxAmount, energyAmount)
-      //     if (sendAmount > 0) {
-      //       const log = this.send(resources, excessResource.resourceType, sendAmount, target.resources)
-      //       if (log != null) {
-      //         logs.push(log)
-      //       }
-      //       return
-      //     }
-      //   }
-      // }
+      if (excessResource != null) {
+        const target = this.resourceInsufficientTarget(roomName, excessResource.resourceType) ?? this.freeSpaceRoom(roomName, excessResource.resourceType)
+        if (target != null) {
+          const energyAmount = resources.terminal.store.getUsedCapacity(RESOURCE_ENERGY)
+          const sendAmount = Math.min(excessResource.sendAmount, target.maxAmount, energyAmount)
+          if (sendAmount > 0) {
+            const log = this.send(resources, excessResource.resourceType, sendAmount, target.resources)
+            if (log != null) {
+              logs.push(log)
+            }
+            return
+          }
+        }
+      }
     })
 
     return logs
@@ -268,7 +273,10 @@ class ResourceTransferer {
         if (targetRoomResource == null) {
           return []
         }
-        if (targetRoomResource.terminal.store.getFreeCapacity(resourceType) < requiredEmptySpace) {
+        if (targetRoomResource.storageSpace !== "empty space") {
+          return []
+        }
+        if (targetRoomResource.freeCapacity.terminal <= 0 || targetRoomResource.freeCapacity.storage <= 0) {
           return []
         }
         if (resourceType === RESOURCE_ENERGY) {
@@ -279,7 +287,7 @@ class ResourceTransferer {
         }
 
         const maxAmount = ((): number => {
-          const freeCapacity = Math.max(targetRoomResource.freeCapacity.terminal - requiredEmptySpace, 0)
+          const freeCapacity = targetRoomResource.freeCapacity.terminal
           if (typeof roomInfo.priority === "number") {
             return Math.min(roomInfo.priority, freeCapacity)
           }
@@ -304,23 +312,33 @@ class ResourceTransferer {
   }
 
   private freeSpaceRoom(fromRoomName: RoomName, resourceType: ResourceConstant): { resources: OwnedRoomResource, maxAmount: number } | null {
+    const resourceRooms: { resources: OwnedRoomResource, maxAmount: number, priority: number }[] = []
     const freeSpaceRooms: { resources: OwnedRoomResource, maxAmount: number, priority: number }[] = []
     this.ownedRoomResources
       .forEach((targetRoomResource, roomName) => {
         if (roomName === fromRoomName) {
           return
         }
-        if (targetRoomResource.terminal.store.getFreeCapacity(resourceType) < requiredEmptySpace) {
+        if (targetRoomResource.storageSpace !== "empty space") {
+          return
+        }
+        if (targetRoomResource.freeCapacity.terminal <= 0 || targetRoomResource.freeCapacity.storage <= 0) {
           return
         }
         if (resourceType === RESOURCE_ENERGY) {
           return
         }
-        const maxAmount = Math.max(targetRoomResource.terminal.store.getFreeCapacity() - requiredEmptySpace, 0)
-        if (maxAmount <= 0) {
-          return
-        }
+        const maxAmount = targetRoomResource.freeCapacity.terminal
         const priority = Game.market.calcTransactionCost(10000, fromRoomName, roomName)
+        const resourceAmount = targetRoomResource.terminal.store.getUsedCapacity(resourceType) + targetRoomResource.storage.store.getUsedCapacity(resourceType)
+
+        if (resourceAmount > 0) {
+          resourceRooms.push({
+            resources: targetRoomResource,
+            maxAmount,
+            priority: priority - resourceAmount,
+          })
+        }
 
         freeSpaceRooms.push({
           resources: targetRoomResource,
@@ -328,6 +346,17 @@ class ResourceTransferer {
           priority,
         })
       })
+
+    const targetRoomResource = resourceRooms.sort()
+      .sort((lhs, rhs) => {
+        if (Math.floor(lhs.priority / transactionCostRound) !== Math.floor(rhs.priority / transactionCostRound)) {
+          return lhs.priority < rhs.priority ? -1 : 1
+        }
+        return lhs.maxAmount > rhs.maxAmount ? -1 : 1
+      })[0]
+    if (targetRoomResource != null) {
+      return targetRoomResource
+    }
 
     return freeSpaceRooms
       .sort((lhs, rhs) => {

--- a/src/process/process/observe_room_process.ts
+++ b/src/process/process/observe_room_process.ts
@@ -15,7 +15,7 @@ export interface ObserveRoomProcessState extends ProcessState {
   readonly until: Timestamp
 }
 
-// Game.io("launch -l ObserveRoomProcess room_name=W48S6 target_room_name=W48S4 duration=100")
+// Game.io("launch -l ObserveRoomProcess room_name=W48S6 target_room_name=W41S7 duration=100")
 export class ObserveRoomProcess implements Process, Procedural {
   private constructor(
     public readonly launchTime: number,

--- a/src/process/process/observe_room_process.ts
+++ b/src/process/process/observe_room_process.ts
@@ -1,0 +1,69 @@
+import { PrimitiveLogger } from "os/infrastructure/primitive_logger"
+import { Procedural } from "process/procedural"
+import { Process, ProcessId } from "process/process"
+import { coloredText, roomLink } from "utility/log"
+import { ProcessState } from "../process_state"
+import { processLog } from "process/process_log"
+import { RoomName } from "utility/room_name"
+import { Timestamp } from "utility/timestamp"
+import { OperatingSystem } from "os/os"
+import { RoomResources } from "room_resource/room_resources"
+
+export interface ObserveRoomProcessState extends ProcessState {
+  readonly roomName: RoomName
+  readonly targetRoomName: RoomName
+  readonly until: Timestamp
+}
+
+// Game.io("launch -l ObserveRoomProcess room_name=W48S6 target_room_name=W48S4 duration=100")
+export class ObserveRoomProcess implements Process, Procedural {
+  private constructor(
+    public readonly launchTime: number,
+    public readonly processId: ProcessId,
+    public readonly roomName: RoomName,
+    public readonly targetRoomName: RoomName,
+    public readonly until: Timestamp,
+  ) { }
+
+  public encode(): ObserveRoomProcessState {
+    return {
+      t: "ObserveRoomProcess",
+      l: this.launchTime,
+      i: this.processId,
+      roomName: this.roomName,
+      targetRoomName: this.targetRoomName,
+      until: this.until,
+    }
+  }
+
+  public static decode(state: ObserveRoomProcessState): ObserveRoomProcess {
+    return new ObserveRoomProcess(state.l, state.i, state.roomName, state.targetRoomName, state.until)
+  }
+
+  public static create(processId: ProcessId, roomName: RoomName, targetRoomName: RoomName, duration: Timestamp): ObserveRoomProcess {
+    return new ObserveRoomProcess(Game.time, processId, roomName, targetRoomName, Game.time + duration)
+  }
+
+  public processShortDescription(): string {
+    return `${roomLink(this.targetRoomName)} in ${this.until - Game.time} ticks`
+  }
+
+  public runOnTick(): void {
+    if (this.until < Game.time) {
+      processLog(this, `${coloredText("Finished", "warn")}`)
+      OperatingSystem.os.killProcess(this.processId)
+      return
+    }
+    const resources = RoomResources.getOwnedRoomResource(this.roomName)
+    if (resources == null) {
+      PrimitiveLogger.fatal(`${roomLink(this.roomName)} lost`)
+      return
+    }
+    if (resources.activeStructures.observer != null) {
+      resources.activeStructures.observer.observeRoom(this.targetRoomName)
+      return
+    }
+
+    // TODO:
+  }
+}

--- a/src/process/process_decoder.ts
+++ b/src/process/process_decoder.ts
@@ -35,6 +35,7 @@ import { World35440623DowngradeControllerProcess, World35440623DowngradeControll
 import { BuyPixelProcess, BuyPixelProcessState } from "./process/buy_pixel_process"
 import { UpgradePowerCreepProcess, UpgradePowerCreepProcessState } from "./process/upgrade_power_creep_process"
 import { InterRoomResourceManagementProcess, InterRoomResourceManagementProcessState } from "./process/inter_room_resource_management_process"
+import { ObserveRoomProcess, ObserveRoomProcessState } from "./process/observe_room_process"
 import type { Process } from "./process"
 import type { ProcessState } from "./process_state"
 import { RoomKeeperProcess, RoomKeeperProcessState } from "./room_keeper_process"
@@ -55,6 +56,7 @@ class ProcessTypes {
   "BootstrapRoomManagerProcess" = (state: ProcessState) => BootstrapRoomManagerProcess.decode(state as unknown as BootstrapRoomManagerProcessState)
   "TaskProcess" = (state: ProcessState) => TaskProcess.decode(state as unknown as TaskProcessState)
   "InterRoomResourceManagementProcess" = (state: ProcessState) => InterRoomResourceManagementProcess.decode(state as unknown as InterRoomResourceManagementProcessState)
+  "ObserveRoomProcess" = (state: ProcessState) => ObserveRoomProcess.decode(state as unknown as ObserveRoomProcessState)
 
   // ---- v6 Process ---- //
   "V6RoomKeeperProcess" = (state: ProcessState) => V6RoomKeeperProcess.decode(state as unknown as V6RoomKeeperProcessState)

--- a/src/process/process_decoder.ts
+++ b/src/process/process_decoder.ts
@@ -31,6 +31,7 @@ import { Season1673282SpecializedQuadProcess, Season1673282SpecializedQuadProces
 import { Season1838855DistributorProcess, Season1838855DistributorProcessState } from "./onetime/season_1838855_distributor_process"
 import { Season2006098StealResourceProcess, Season2006098StealResourceProcessState } from "./onetime/season_2006098_steal_resource_process"
 import { Season2055924SendResourcesProcess, Season2055924SendResourcesProcessState } from "./onetime/season_2055924_send_resources_process"
+import { World35440623DowngradeControllerProcess, World35440623DowngradeControllerProcessState } from "./onetime/world_35440623_downgrade_controller_process"
 import { BuyPixelProcess, BuyPixelProcessState } from "./process/buy_pixel_process"
 import { UpgradePowerCreepProcess, UpgradePowerCreepProcessState } from "./process/upgrade_power_creep_process"
 import { InterRoomResourceManagementProcess, InterRoomResourceManagementProcessState } from "./process/inter_room_resource_management_process"
@@ -88,6 +89,7 @@ class ProcessTypes {
   "Season1838855DistributorProcess" = (state: ProcessState) => Season1838855DistributorProcess.decode(state as unknown as Season1838855DistributorProcessState)
   "Season2006098StealResourceProcess" = (state: ProcessState) => Season2006098StealResourceProcess.decode(state as unknown as Season2006098StealResourceProcessState)
   "Season2055924SendResourcesProcess" = (state: ProcessState) => Season2055924SendResourcesProcess.decode(state as unknown as Season2055924SendResourcesProcessState)
+  "World35440623DowngradeControllerProcess" = (state: ProcessState) => World35440623DowngradeControllerProcess.decode(state as unknown as World35440623DowngradeControllerProcessState)
 }
 
 export function decodeProcessFrom(state: ProcessState): Process | null {

--- a/src/room_plan/room_planner.ts
+++ b/src/room_plan/room_planner.ts
@@ -438,6 +438,11 @@ function calculateFirstSpawnPosition(controller: StructureController, showsCostM
     return spawn.pos
   }
 
+  const spawnFlag = room.find(FIND_FLAGS).find(flag => flag.color === COLOR_GREY)
+  if (spawnFlag != null) {
+    return spawnFlag.pos
+  }
+
   const positionScores = ErrorMapper.wrapLoop((): { position: RoomPosition, score: number }[] => {
     return roomOpenPositions(room, showsCostMatrix)
   }, "roomOpenPositions()")()

--- a/src/room_resource/room_info.ts
+++ b/src/room_resource/room_info.ts
@@ -62,6 +62,7 @@ export interface OwnedRoomInfo extends BasicRoomInfo {
     researchCompounds?: { [index in MineralCompoundConstant]?: number }
     collectResources?: boolean
     boostLabs?: Id<StructureLab>[]
+    excludedRemotes?: RoomName[]
   }
 }
 

--- a/src/utility/environment.ts
+++ b/src/utility/environment.ts
@@ -1,8 +1,9 @@
 type PersistentWorld = "persistent world"
 type SimulationWorld = "simulation"
 type Season3 = "season 3"
+type BotArena = "botarena"
 
-type World = PersistentWorld | SimulationWorld | Season3
+type World = PersistentWorld | SimulationWorld | Season3 | BotArena
 type ShardName = string
 
 export interface Environment {
@@ -16,8 +17,14 @@ const world = ((): World => {
     return "simulation"
   case "shardSeason":
     return "season 3"
-  default:
+  case "shard0":
+  case "shard1":
+  case "shard2":
+  case "shard3":
     return "persistent world"
+  case "botarena":
+  default:
+    return "botarena"
   }
 })()
 

--- a/src/utility/system_info.ts
+++ b/src/utility/system_info.ts
@@ -19,7 +19,7 @@ export const SystemInfo = {
     name: "AntOS",
   },
   application: {
-    version: "6.7.11",
+    version: "6.7.12",
     shortVersionString: ShortVersion.v6,
     name: "DecisionMaker",
   },

--- a/src/utility/system_info.ts
+++ b/src/utility/system_info.ts
@@ -19,7 +19,7 @@ export const SystemInfo = {
     name: "AntOS",
   },
   application: {
-    version: "6.7.20",
+    version: "6.7.21",
     shortVersionString: ShortVersion.v6,
     name: "DecisionMaker",
   },

--- a/src/utility/system_info.ts
+++ b/src/utility/system_info.ts
@@ -19,7 +19,7 @@ export const SystemInfo = {
     name: "AntOS",
   },
   application: {
-    version: "6.7.9",
+    version: "6.7.11",
     shortVersionString: ShortVersion.v6,
     name: "DecisionMaker",
   },

--- a/src/utility/system_info.ts
+++ b/src/utility/system_info.ts
@@ -19,7 +19,7 @@ export const SystemInfo = {
     name: "AntOS",
   },
   application: {
-    version: "6.7.32",
+    version: "6.7.33",
     shortVersionString: ShortVersion.v6,
     name: "DecisionMaker",
   },

--- a/src/utility/system_info.ts
+++ b/src/utility/system_info.ts
@@ -19,7 +19,7 @@ export const SystemInfo = {
     name: "AntOS",
   },
   application: {
-    version: "6.7.18",
+    version: "6.7.19",
     shortVersionString: ShortVersion.v6,
     name: "DecisionMaker",
   },

--- a/src/utility/system_info.ts
+++ b/src/utility/system_info.ts
@@ -19,7 +19,7 @@ export const SystemInfo = {
     name: "AntOS",
   },
   application: {
-    version: "6.7.34",
+    version: "6.7.37",
     shortVersionString: ShortVersion.v6,
     name: "DecisionMaker",
   },

--- a/src/utility/system_info.ts
+++ b/src/utility/system_info.ts
@@ -19,7 +19,7 @@ export const SystemInfo = {
     name: "AntOS",
   },
   application: {
-    version: "6.7.8",
+    version: "6.7.9",
     shortVersionString: ShortVersion.v6,
     name: "DecisionMaker",
   },

--- a/src/utility/system_info.ts
+++ b/src/utility/system_info.ts
@@ -19,7 +19,7 @@ export const SystemInfo = {
     name: "AntOS",
   },
   application: {
-    version: "6.7.6",
+    version: "6.7.7",
     shortVersionString: ShortVersion.v6,
     name: "DecisionMaker",
   },

--- a/src/utility/system_info.ts
+++ b/src/utility/system_info.ts
@@ -19,7 +19,7 @@ export const SystemInfo = {
     name: "AntOS",
   },
   application: {
-    version: "6.7.16",
+    version: "6.7.17",
     shortVersionString: ShortVersion.v6,
     name: "DecisionMaker",
   },

--- a/src/utility/system_info.ts
+++ b/src/utility/system_info.ts
@@ -19,7 +19,7 @@ export const SystemInfo = {
     name: "AntOS",
   },
   application: {
-    version: "6.7.31",
+    version: "6.7.32",
     shortVersionString: ShortVersion.v6,
     name: "DecisionMaker",
   },

--- a/src/utility/system_info.ts
+++ b/src/utility/system_info.ts
@@ -19,7 +19,7 @@ export const SystemInfo = {
     name: "AntOS",
   },
   application: {
-    version: "6.7.26",
+    version: "6.7.27",
     shortVersionString: ShortVersion.v6,
     name: "DecisionMaker",
   },

--- a/src/utility/system_info.ts
+++ b/src/utility/system_info.ts
@@ -19,7 +19,7 @@ export const SystemInfo = {
     name: "AntOS",
   },
   application: {
-    version: "6.7.0",
+    version: "6.7.1",
     shortVersionString: ShortVersion.v6,
     name: "DecisionMaker",
   },

--- a/src/utility/system_info.ts
+++ b/src/utility/system_info.ts
@@ -19,7 +19,7 @@ export const SystemInfo = {
     name: "AntOS",
   },
   application: {
-    version: "6.7.17",
+    version: "6.7.18",
     shortVersionString: ShortVersion.v6,
     name: "DecisionMaker",
   },

--- a/src/utility/system_info.ts
+++ b/src/utility/system_info.ts
@@ -19,7 +19,7 @@ export const SystemInfo = {
     name: "AntOS",
   },
   application: {
-    version: "6.7.33",
+    version: "6.7.34",
     shortVersionString: ShortVersion.v6,
     name: "DecisionMaker",
   },

--- a/src/utility/system_info.ts
+++ b/src/utility/system_info.ts
@@ -19,7 +19,7 @@ export const SystemInfo = {
     name: "AntOS",
   },
   application: {
-    version: "6.7.27",
+    version: "6.7.28",
     shortVersionString: ShortVersion.v6,
     name: "DecisionMaker",
   },

--- a/src/utility/system_info.ts
+++ b/src/utility/system_info.ts
@@ -19,7 +19,7 @@ export const SystemInfo = {
     name: "AntOS",
   },
   application: {
-    version: "6.7.21",
+    version: "6.7.26",
     shortVersionString: ShortVersion.v6,
     name: "DecisionMaker",
   },

--- a/src/utility/system_info.ts
+++ b/src/utility/system_info.ts
@@ -19,7 +19,7 @@ export const SystemInfo = {
     name: "AntOS",
   },
   application: {
-    version: "6.7.28",
+    version: "6.7.29",
     shortVersionString: ShortVersion.v6,
     name: "DecisionMaker",
   },

--- a/src/utility/system_info.ts
+++ b/src/utility/system_info.ts
@@ -19,7 +19,7 @@ export const SystemInfo = {
     name: "AntOS",
   },
   application: {
-    version: "6.7.3",
+    version: "6.7.4",
     shortVersionString: ShortVersion.v6,
     name: "DecisionMaker",
   },

--- a/src/utility/system_info.ts
+++ b/src/utility/system_info.ts
@@ -19,7 +19,7 @@ export const SystemInfo = {
     name: "AntOS",
   },
   application: {
-    version: "6.7.30",
+    version: "6.7.31",
     shortVersionString: ShortVersion.v6,
     name: "DecisionMaker",
   },

--- a/src/utility/system_info.ts
+++ b/src/utility/system_info.ts
@@ -19,7 +19,7 @@ export const SystemInfo = {
     name: "AntOS",
   },
   application: {
-    version: "6.7.12",
+    version: "6.7.13",
     shortVersionString: ShortVersion.v6,
     name: "DecisionMaker",
   },

--- a/src/utility/system_info.ts
+++ b/src/utility/system_info.ts
@@ -19,7 +19,7 @@ export const SystemInfo = {
     name: "AntOS",
   },
   application: {
-    version: "6.7.15",
+    version: "6.7.16",
     shortVersionString: ShortVersion.v6,
     name: "DecisionMaker",
   },

--- a/src/utility/system_info.ts
+++ b/src/utility/system_info.ts
@@ -19,7 +19,7 @@ export const SystemInfo = {
     name: "AntOS",
   },
   application: {
-    version: "6.7.29",
+    version: "6.7.30",
     shortVersionString: ShortVersion.v6,
     name: "DecisionMaker",
   },

--- a/src/utility/system_info.ts
+++ b/src/utility/system_info.ts
@@ -19,7 +19,7 @@ export const SystemInfo = {
     name: "AntOS",
   },
   application: {
-    version: "6.7.5",
+    version: "6.7.6",
     shortVersionString: ShortVersion.v6,
     name: "DecisionMaker",
   },

--- a/src/utility/system_info.ts
+++ b/src/utility/system_info.ts
@@ -19,7 +19,7 @@ export const SystemInfo = {
     name: "AntOS",
   },
   application: {
-    version: "6.7.19",
+    version: "6.7.20",
     shortVersionString: ShortVersion.v6,
     name: "DecisionMaker",
   },

--- a/src/utility/system_info.ts
+++ b/src/utility/system_info.ts
@@ -19,7 +19,7 @@ export const SystemInfo = {
     name: "AntOS",
   },
   application: {
-    version: "6.7.4",
+    version: "6.7.5",
     shortVersionString: ShortVersion.v6,
     name: "DecisionMaker",
   },

--- a/src/utility/system_info.ts
+++ b/src/utility/system_info.ts
@@ -19,7 +19,7 @@ export const SystemInfo = {
     name: "AntOS",
   },
   application: {
-    version: "6.7.14",
+    version: "6.7.15",
     shortVersionString: ShortVersion.v6,
     name: "DecisionMaker",
   },

--- a/src/utility/system_info.ts
+++ b/src/utility/system_info.ts
@@ -19,7 +19,7 @@ export const SystemInfo = {
     name: "AntOS",
   },
   application: {
-    version: "6.7.1",
+    version: "6.7.3",
     shortVersionString: ShortVersion.v6,
     name: "DecisionMaker",
   },

--- a/src/utility/system_info.ts
+++ b/src/utility/system_info.ts
@@ -19,7 +19,7 @@ export const SystemInfo = {
     name: "AntOS",
   },
   application: {
-    version: "6.7.13",
+    version: "6.7.14",
     shortVersionString: ShortVersion.v6,
     name: "DecisionMaker",
   },

--- a/src/utility/system_info.ts
+++ b/src/utility/system_info.ts
@@ -19,7 +19,7 @@ export const SystemInfo = {
     name: "AntOS",
   },
   application: {
-    version: "6.7.7",
+    version: "6.7.8",
     shortVersionString: ShortVersion.v6,
     name: "DecisionMaker",
   },

--- a/src/v5_object_task/creep_task/api_wrapper/attack_controller_api_wrapper.ts
+++ b/src/v5_object_task/creep_task/api_wrapper/attack_controller_api_wrapper.ts
@@ -1,0 +1,77 @@
+import { PrimitiveLogger } from "os/infrastructure/primitive_logger"
+import { ERR_DAMAGED, ERR_PROGRAMMING_ERROR, FINISHED, FINISHED_AND_RAN, IN_PROGRESS } from "prototype/creep"
+import { ApiWrapper } from "v5_object_task/api_wrapper"
+import { TargetingApiWrapper } from "v5_object_task/targeting_api_wrapper"
+import { roomLink } from "utility/log"
+import { CreepApiWrapperState } from "../creep_api_wrapper"
+import { Sign } from "game/sign"
+
+type AttackControllerApiWrapperResult = FINISHED | FINISHED_AND_RAN | IN_PROGRESS | ERR_NOT_IN_RANGE | ERR_BUSY | ERR_DAMAGED | ERR_PROGRAMMING_ERROR
+
+export interface AttackControllerApiWrapperState extends CreepApiWrapperState {
+  /** target id */
+  i: Id<StructureController>
+}
+
+export class AttackControllerApiWrapper implements ApiWrapper<Creep, AttackControllerApiWrapperResult>, TargetingApiWrapper {
+  public readonly shortDescription = "downgrade"
+  public readonly range = 1
+
+  private constructor(
+    public readonly target: StructureController,
+  ) { }
+
+  public encode(): AttackControllerApiWrapperState {
+    return {
+      t: "AttackControllerApiWrapper",
+      i: this.target.id,
+    }
+  }
+
+  public static decode(state: AttackControllerApiWrapperState): AttackControllerApiWrapper | null {
+    const target = Game.getObjectById(state.i)
+    if (target == null) {
+      return null
+    }
+    return new AttackControllerApiWrapper(target)
+  }
+
+  public static create(target: StructureController): AttackControllerApiWrapper {
+    return new AttackControllerApiWrapper(target)
+  }
+
+  public run(creep: Creep): AttackControllerApiWrapperResult {
+    if (this.target.owner == null || this.target.my === true) {
+      return FINISHED
+    }
+
+    const result = creep.attackController(this.target)
+    if (this.target.sign == null || this.target.sign.username !== Game.user.name) {
+      creep.signController(this.target, Sign.signForHostileRoom())
+    }
+
+    switch (result) {
+    case OK: {
+      return FINISHED_AND_RAN
+    }
+
+    case ERR_TIRED:
+      return FINISHED
+
+    case ERR_NOT_IN_RANGE:
+      return ERR_NOT_IN_RANGE
+
+    case ERR_BUSY:
+      return ERR_BUSY
+
+    case ERR_NO_BODYPART:
+      return ERR_DAMAGED
+
+    case ERR_NOT_OWNER:
+    case ERR_INVALID_TARGET:
+    default:
+      PrimitiveLogger.fatal(`creep.attackController() returns ${result}, ${creep.name}, construction site ${this.target} in ${roomLink(creep.room.name)}`)
+      return ERR_PROGRAMMING_ERROR
+    }
+  }
+}

--- a/src/v5_object_task/creep_task/api_wrapper/claim_controller_api_wrapper.ts
+++ b/src/v5_object_task/creep_task/api_wrapper/claim_controller_api_wrapper.ts
@@ -40,7 +40,7 @@ export class ClaimControllerApiWrapper implements ApiWrapper<Creep, ClaimControl
   }
 
   public run(creep: Creep): ClaimControllerApiWrapperResult {
-    const result = creep.claimController(this.target)
+    const result = (this.target.reservation == null) ? creep.claimController(this.target) : creep.attackController(this.target)
     creep.signController(this.target, Sign.signForOwnedRoom())
 
     switch (result) {
@@ -61,6 +61,7 @@ export class ClaimControllerApiWrapper implements ApiWrapper<Creep, ClaimControl
       creep.reserveController(this.target)
       return IN_PROGRESS
 
+    case ERR_NOT_OWNER:
     case ERR_INVALID_TARGET:
     case ERR_FULL:
     default:

--- a/src/v5_object_task/creep_task/combined_task/move_to_target_task.ts
+++ b/src/v5_object_task/creep_task/combined_task/move_to_target_task.ts
@@ -41,7 +41,7 @@ export class MoveToTargetTask implements CreepTask {
 
   private constructor(
     public readonly startTime: number,
-    private readonly apiWrapper: MoveToTargetTaskApiWrapper,
+    public readonly apiWrapper: MoveToTargetTaskApiWrapper,
     private readonly options: MoveToTargetTaskOptions,
     private lastPosition: Position | null,
   ) {

--- a/src/v5_object_task/creep_task/creep_api_wrapper.ts
+++ b/src/v5_object_task/creep_task/creep_api_wrapper.ts
@@ -22,6 +22,7 @@ import { BoostApiWrapper, BoostApiWrapperState } from "./api_wrapper/boost_api_w
 import { RangedAttackApiWrapper, RangedAttackApiWrapperState } from "./api_wrapper/ranged_attack_api_wrapper"
 import { HealApiWrapper, HealApiWrapperState } from "./api_wrapper/heal_api_wrapper"
 import { PickupApiWrapper, PickupApiWrapperState } from "./api_wrapper/pickup_api_wrapper"
+import { AttackControllerApiWrapper, AttackControllerApiWrapperState } from "./api_wrapper/attack_controller_api_wrapper"
 
 export interface CreepApiWrapperState extends ApiWrapperState {
   t: keyof CreepApiWrapperDecoderMap
@@ -56,6 +57,7 @@ type CreepApiWrapperType = HarvestEnergyApiWrapper
   | RangedAttackApiWrapper
   | HealApiWrapper
   | PickupApiWrapper
+  | AttackControllerApiWrapper
 
 class CreepApiWrapperDecoderMap {
   // force castしてdecode()するため返り値はnullableではない。代わりに呼び出す際はErrorMapperで囲う
@@ -80,6 +82,7 @@ class CreepApiWrapperDecoderMap {
   "RangedAttackApiWrapper" = (state: CreepApiWrapperState) => RangedAttackApiWrapper.decode(state as RangedAttackApiWrapperState)
   "HealApiWrapper" = (state: CreepApiWrapperState) => HealApiWrapper.decode(state as HealApiWrapperState)
   "PickupApiWrapper" = (state: CreepApiWrapperState) => PickupApiWrapper.decode(state as PickupApiWrapperState)
+  "AttackControllerApiWrapper" = (state: CreepApiWrapperState) => AttackControllerApiWrapper.decode(state as AttackControllerApiWrapperState)
 }
 const decoderMap = new CreepApiWrapperDecoderMap()
 

--- a/src/v5_object_task/creep_task/meta_task/move_to_room_task.ts
+++ b/src/v5_object_task/creep_task/meta_task/move_to_room_task.ts
@@ -101,7 +101,20 @@ export class MoveToRoomTask implements CreepTask {
       return nextWaypoint
     })()
 
-    const reusePath = 20
+    const reusePath = ((): number => {
+      const defaultValue = 20
+      const controller = creep.room.controller
+      if (controller == null) {
+        return defaultValue
+      }
+      if (controller.owner != null) {
+        return 3
+      }
+      if (controller.reservation != null) {
+        return 5
+      }
+      return defaultValue
+    })()
     const noPathFindingOptions: MoveToOpts = {
       noPathFinding: true,
       reusePath,

--- a/src/v5_problem/invasion/room_invaded_problem_finder.ts
+++ b/src/v5_problem/invasion/room_invaded_problem_finder.ts
@@ -30,7 +30,7 @@ export class RoomInvadedProblemFinder implements ProblemFinder {
       problemSolvers.push(TowerInterceptionProblemSolver.create(this.identifier, this.roomName))
     }
     const roomObjects = World.rooms.getOwnedRoomObjects(this.roomName)
-    if (roomObjects != null && roomObjects.controller.safeMode == null) {
+    if (this.objects.roomInfo.bootstrapping !== true && roomObjects != null && roomObjects.controller.safeMode == null) {
       const shouldActivateSafemode = ((): boolean => {
         for (const hostileCreep of roomObjects.hostiles.creeps) {
           if (hostileCreep.getActiveBodyparts(ATTACK) > 0 || hostileCreep.getActiveBodyparts(RANGED_ATTACK) > 0 || hostileCreep.getActiveBodyparts(WORK) > 0) {

--- a/src/v5_task/bootstrap_room/claim_room_task.ts
+++ b/src/v5_task/bootstrap_room/claim_room_task.ts
@@ -18,12 +18,12 @@ export function shouldSpawnBootstrapCreeps(targetRoomName: RoomName): boolean {
     return true
   }
   if (targetRoomInfo.roomType !== "normal") {
-    return false
+    return true
   }
   if (targetRoomInfo.owner == null) {
     return true
   }
-  if (targetRoomInfo.owner.ownerType === "claim") {
+  if (targetRoomInfo.owner.ownerType === "claim" && targetRoomInfo.owner.username !== Game.user.name) {
     return false
   }
   return true

--- a/src/v5_task/bootstrap_room/claim_room_task.ts
+++ b/src/v5_task/bootstrap_room/claim_room_task.ts
@@ -12,6 +12,23 @@ import { World } from "world_info/world_info"
 import { RoomResources } from "room_resource/room_resources"
 import { CreepBody } from "utility/creep_body"
 
+export function shouldSpawnBootstrapCreeps(targetRoomName: RoomName): boolean {
+  const targetRoomInfo = RoomResources.getRoomInfo(targetRoomName)
+  if (targetRoomInfo == null) {
+    return true
+  }
+  if (targetRoomInfo.roomType !== "normal") {
+    return false
+  }
+  if (targetRoomInfo.owner == null) {
+    return true
+  }
+  if (targetRoomInfo.owner.ownerType === "claim") {
+    return false
+  }
+  return true
+}
+
 export interface ClaimRoomTaskState extends GeneralCreepWorkerTaskState {
   /** room name */
   r: RoomName
@@ -80,6 +97,10 @@ export class ClaimRoomTask extends GeneralCreepWorkerTask {
   }
 
   public creepRequest(): GeneralCreepWorkerTaskCreepRequest | null {
+    if (shouldSpawnBootstrapCreeps(this.targetRoomName) !== true) {
+      return null
+    }
+
     const creepTask = MoveClaimControllerTask.create(this.targetRoomName, this.waypoints, true)
     const body = ((): BodyPartConstant[] => {
       const defaultBody = [MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, MOVE, CLAIM]

--- a/src/v5_task/bootstrap_room/upgrade_to_rcl3_task.ts
+++ b/src/v5_task/bootstrap_room/upgrade_to_rcl3_task.ts
@@ -277,7 +277,7 @@ export class UpgradeToRcl3Task extends GeneralCreepWorkerTask {
       if (neighbourRoomInfo == null) {
         return []
       }
-      if (neighbourRoomInfo.roomType !== "normal") {
+      if (neighbourRoomInfo.roomType !== "normal" || roomTypeOf(neighbourRoomName) !== "normal") {
         return []
       }
       if (neighbourRoomInfo.owner != null) {

--- a/src/v5_task/bootstrap_room/upgrade_to_rcl3_task.ts
+++ b/src/v5_task/bootstrap_room/upgrade_to_rcl3_task.ts
@@ -21,6 +21,7 @@ import { RepairApiWrapper } from "v5_object_task/creep_task/api_wrapper/repair_a
 import { bodyCost } from "utility/creep_body"
 import { TempRenewApiWrapper } from "v5_object_task/creep_task/api_wrapper/temp_renew_api_wrapper"
 import { RoomResources } from "room_resource/room_resources"
+import { shouldSpawnBootstrapCreeps } from "./claim_room_task"
 
 const minimumNumberOfCreeps = 6
 const defaultNumberOfCreeps = 10
@@ -121,6 +122,10 @@ export class UpgradeToRcl3Task extends GeneralCreepWorkerTask {
   }
 
   public creepRequest(objects: OwnedRoomObjects): GeneralCreepWorkerTaskCreepRequest | null {
+    if (shouldSpawnBootstrapCreeps(this.targetRoomName) !== true) {
+      return null
+    }
+
     const numberOfCreeps = ((): number => {
       if (this.targetRoomName === "W11S14" || this.targetRoomName === "W17S11") {
         const targetRoom = Game.rooms[this.targetRoomName]

--- a/src/v5_task/hauler/owned_room_hauler_task.ts
+++ b/src/v5_task/hauler/owned_room_hauler_task.ts
@@ -92,7 +92,7 @@ export class OwnedRoomHaulerTask extends Task {
         if (storage == null) {
           return baseCount
         }
-        this.storageDistance = objects.sources.reduce((result, current) => result + current.pos.getRangeTo(storage.pos), 0)
+        this.storageDistance = objects.sources.reduce((result, current) => result + current.pos.findPathTo(storage.pos).length, 0)
       }
       const countBasedOnDistance = Math.ceil((baseCount / 2) * (this.storageDistance / 10)) * 0.8
       return Math.max(countBasedOnDistance, baseCount)
@@ -103,7 +103,7 @@ export class OwnedRoomHaulerTask extends Task {
     ]
 
     if (objects.activeStructures.storage != null) {
-      const problemFinder = this.createCreepInsufficiencyProblemFinder(objects, necessaryRoles, filterTaskIdentifier, minimumCreepCount, null, CreepSpawnRequestPriority.Medium)
+      const problemFinder = this.createCreepInsufficiencyProblemFinder(objects, necessaryRoles, filterTaskIdentifier, minimumCreepCount, null, CreepSpawnRequestPriority.Low)
       problemFinders.push(problemFinder)
     }
 

--- a/src/v5_task/hauler/owned_room_hauler_task.ts
+++ b/src/v5_task/hauler/owned_room_hauler_task.ts
@@ -94,7 +94,8 @@ export class OwnedRoomHaulerTask extends Task {
         }
         this.storageDistance = objects.sources.reduce((result, current) => result + current.pos.getRangeTo(storage.pos), 0)
       }
-      return Math.max(Math.ceil((baseCount / 2) * (this.storageDistance / 10)), baseCount)
+      const countBasedOnDistance = Math.ceil((baseCount / 2) * (this.storageDistance / 10)) * 0.8
+      return Math.max(countBasedOnDistance, baseCount)
     })()
     const creepPoolFilter: CreepPoolFilter = creep => hasNecessaryRoles(creep, necessaryRoles)
 

--- a/src/v5_task/remote_room_keeper/remote_room_keeper_task.ts
+++ b/src/v5_task/remote_room_keeper/remote_room_keeper_task.ts
@@ -113,6 +113,11 @@ export class RemoteRoomKeeperTask extends Task {
     const targetRoom = Game.rooms[this.targetRoomName]
     if (targetRoom != null && targetRoomInfo != null && targetRoomInfo.roomType === "normal") {
       const shouldLaunchRemoteRoomWorker = ((): boolean => {
+        const resources = RoomResources.getOwnedRoomResource(this.roomName)
+        const excludedRemotes = resources?.roomInfo.config?.excludedRemotes
+        if (excludedRemotes != null && excludedRemotes.includes(this.targetRoomName) === true) {
+          return false
+        }
         if (this.children.some(task => task instanceof RemoteRoomWorkerTask) === true) {
           const remoteRoomNames = remoteRoomNamesToDefend.getValueFor(this.roomName)
           if (remoteRoomNames.includes(this.targetRoomName) !== true) {
@@ -128,9 +133,6 @@ export class RemoteRoomKeeperTask extends Task {
           if (remoteRooms.includes(this.targetRoomName) === true) {
             return true
           }
-        }
-        if (Environment.world === "persistent world" && Environment.shard === "shard2" && this.roomName === "W53S5" && this.targetRoomName === "W53S6") {  // 起動中のRemoteRoomWorkerを削除したい場合
-          return false
         }
         if (Environment.world === "season 3") {
           return false
@@ -157,7 +159,7 @@ export class RemoteRoomKeeperTask extends Task {
       if (!(task instanceof RemoteRoomWorkerTask)) {
         return false
       }
-      if (Environment.world === "persistent world" && Environment.shard === "shard2" && task.roomName === "W53S5" && task.targetRoomName === "W53S6") {  // 起動中のRemoteRoomWorkerを削除したい場合
+      if (Environment.world === "persistent world" && Environment.shard === "shard2" && task.roomName === "W53S5" && task.targetRoomName === "W53S4") {  // 起動中のRemoteRoomWorkerを削除したい場合
         return true
       }
       return false

--- a/src/v5_task/remote_room_keeper/remote_room_keeper_task.ts
+++ b/src/v5_task/remote_room_keeper/remote_room_keeper_task.ts
@@ -63,6 +63,10 @@ export class RemoteRoomKeeperTask extends Task {
     const problemFinders: ProblemFinder[] = [
     ]
 
+    const ownerNameWhitelist: string[] = [
+      Invader.username,
+      Game.user.name,
+    ]
     const targetRoomInfo = RoomResources.getRoomInfo(this.targetRoomName)
     const shouldCheckInvisibility = ((): boolean => {
       if (targetRoomInfo == null) {
@@ -77,10 +81,10 @@ export class RemoteRoomKeeperTask extends Task {
       if (targetRoomInfo.owner == null) {
         return true
       }
-      if (targetRoomInfo.owner.ownerType === "reserve" && targetRoomInfo.owner.username === Invader.username) {
+      if (targetRoomInfo.owner.ownerType === "reserve" && ownerNameWhitelist.includes(targetRoomInfo.owner.username) === true) {
         return true
       }
-      if (((Game.time + this.startTime) % 4099) < 100) {
+      if (((Game.time + this.startTime) % 1511) < 40) {
         return true
       }
       return false
@@ -132,7 +136,10 @@ export class RemoteRoomKeeperTask extends Task {
           return false
         }
         if (targetRoomInfo.owner != null) {
-          if (targetRoomInfo.owner.ownerType !== "reserve" || targetRoomInfo.owner.username !== Invader.username) {
+          if (targetRoomInfo.owner.ownerType === "claim") {
+            return false
+          }
+          if (ownerNameWhitelist.includes(targetRoomInfo.owner.username) !== true) {
             return false
           }
         }

--- a/src/v5_task/remote_room_keeper/remote_room_keeper_task.ts
+++ b/src/v5_task/remote_room_keeper/remote_room_keeper_task.ts
@@ -159,7 +159,7 @@ export class RemoteRoomKeeperTask extends Task {
       if (!(task instanceof RemoteRoomWorkerTask)) {
         return false
       }
-      if (Environment.world === "persistent world" && Environment.shard === "shard2" && task.roomName === "W53S5" && task.targetRoomName === "W53S4") {  // 起動中のRemoteRoomWorkerを削除したい場合
+      if (Environment.world === "persistent world" && Environment.shard === "shard2" && task.roomName === "W52S28" && task.targetRoomName === "W52S29") {  // 起動中のRemoteRoomWorkerを削除したい場合
         return true
       }
       return false

--- a/src/v5_task/remote_room_keeper/remote_room_keeper_task.ts
+++ b/src/v5_task/remote_room_keeper/remote_room_keeper_task.ts
@@ -159,7 +159,7 @@ export class RemoteRoomKeeperTask extends Task {
       if (!(task instanceof RemoteRoomWorkerTask)) {
         return false
       }
-      if (Environment.world === "persistent world" && Environment.shard === "shard2" && task.roomName === "W52S28" && task.targetRoomName === "W52S29") {  // 起動中のRemoteRoomWorkerを削除したい場合
+      if (Environment.world === "persistent world" && Environment.shard === "shard3" && task.roomName === "W48S33" && task.targetRoomName === "W49S33") {  // 起動中のRemoteRoomWorkerを削除したい場合
         return true
       }
       return false

--- a/src/v5_task/room_keeper/room_keeper_task.ts
+++ b/src/v5_task/room_keeper/room_keeper_task.ts
@@ -16,6 +16,7 @@ import { coloredText, roomLink } from "utility/log"
 import { Season1838855DistributorProcess } from "process/onetime/season_1838855_distributor_process"
 import { OperatingSystem } from "os/os"
 import { RoomPlanner } from "room_plan/room_planner"
+import { WallBuilderTaskMaxWallHits } from "application/task/wall/wall_builder_task"
 
 export interface RoomKeeperTaskState extends TaskState {
   /** room name */
@@ -153,6 +154,9 @@ export class RoomKeeperTask extends Task {
       structure.destroy()
     })
     room.find(FIND_STRUCTURES, { filter: { structureType: STRUCTURE_WALL } }).forEach(structure => {
+      if (structure.hits >= WallBuilderTaskMaxWallHits) {
+        return
+      }
       structure.destroy()
     })
   }

--- a/src/v5_task/room_keeper/room_keeper_task.ts
+++ b/src/v5_task/room_keeper/room_keeper_task.ts
@@ -134,7 +134,17 @@ export class RoomKeeperTask extends Task {
     ]
     room.find(FIND_HOSTILE_STRUCTURES).forEach(structure => {
       if (excludedHostileStructures.includes(structure.structureType) === true) {
-        return
+        try {
+          const store = (structure as { store?: StoreDefinition }).store
+          if (store == null) {
+            return
+          }
+          if (store.getUsedCapacity() > 0) {
+            return
+          }
+        } catch (e) {
+          PrimitiveLogger.programError(`${this.taskIdentifier} removeLeftoverStructures() failed: ${e}`)
+        }
       }
       structure.destroy()
     })

--- a/src/v5_task/room_keeper/room_keeper_task.ts
+++ b/src/v5_task/room_keeper/room_keeper_task.ts
@@ -112,6 +112,7 @@ export class RoomKeeperTask extends Task {
             } catch (e) {
               PrimitiveLogger.fatal(`${this.taskIdentifier} failed to launch distributor process ${e} ${roomLink(this.roomName)}`)
             }
+            this.removeLeftoverStructures(objects.controller.room)
             break
           case "failed":
             PrimitiveLogger.fatal(`${this.taskIdentifier} ${roomLink(this.roomName)} ${result.reason}`)
@@ -123,5 +124,26 @@ export class RoomKeeperTask extends Task {
     }
 
     return TaskStatus.InProgress
+  }
+
+  private removeLeftoverStructures(room: Room): void {
+    const excludedHostileStructures: StructureConstant[] = [
+      STRUCTURE_STORAGE,
+      STRUCTURE_TERMINAL,
+      STRUCTURE_FACTORY,
+    ]
+    room.find(FIND_HOSTILE_STRUCTURES).forEach(structure => {
+      if (excludedHostileStructures.includes(structure.structureType) === true) {
+        return
+      }
+      structure.destroy()
+    })
+
+    room.find(FIND_STRUCTURES, { filter: { structureType: STRUCTURE_ROAD } }).forEach(structure => {
+      structure.destroy()
+    })
+    room.find(FIND_STRUCTURES, { filter: { structureType: STRUCTURE_WALL } }).forEach(structure => {
+      structure.destroy()
+    })
   }
 }

--- a/src/v5_task/upgrader/upgrader_task.ts
+++ b/src/v5_task/upgrader/upgrader_task.ts
@@ -17,7 +17,6 @@ import { GetEnergyApiWrapper } from "v5_object_task/creep_task/api_wrapper/get_e
 import { UpgradeControllerApiWrapper } from "v5_object_task/creep_task/api_wrapper/upgrade_controller_api_wrapper"
 import { bodyCost } from "utility/creep_body"
 import { RoomResources } from "room_resource/room_resources"
-import { coloredText } from "utility/log"
 
 export interface UpgraderTaskState extends GeneralCreepWorkerTaskState {
   /** room name */
@@ -271,6 +270,7 @@ export class UpgraderTask extends GeneralCreepWorkerTask {
       })
       if (link != null) {
         this.linkId = link.id
+        PrimitiveLogger.log(`${this.taskIdentifier} link id set: link ${link.pos}`)
       }
     }
     if (objects.roomInfo.upgrader?.container == null) {

--- a/src/v5_task/worker/general_worker_task.ts
+++ b/src/v5_task/worker/general_worker_task.ts
@@ -85,7 +85,8 @@ export class GeneralWorkerTask extends Task {
 
   // ---- Problem Solver ---- //
   private createCreepInsufficiencyProblemFinder(objects: OwnedRoomObjects, roles: CreepRole[], filterTaskIdentifier: TaskIdentifier | null): ProblemFinder {
-    const roomName = objects.controller.room.name
+    const room = objects.controller.room
+    const roomName = room.name
     const minimumCreepCount = ((): number => {
       if (objects.activeStructures.storage == null) {
         return 5
@@ -96,7 +97,8 @@ export class GeneralWorkerTask extends Task {
     const problemFinder = new CreepInsufficiencyProblemFinder(roomName, roles, roles, filterTaskIdentifier, minimumCreepCount)
 
     const noCreeps = problemFinder.creepCount < 2
-    const body = noCreeps ? [CARRY, WORK, MOVE] : this.workerBody(objects)
+    const energyCapacity = noCreeps === true ? room.energyAvailable : room.energyCapacityAvailable
+    const body = this.workerBody(energyCapacity)
     const priority = noCreeps ? CreepSpawnRequestPriority.Urgent : CreepSpawnRequestPriority.Medium
 
     const problemFinderWrapper: ProblemFinder = {
@@ -120,7 +122,7 @@ export class GeneralWorkerTask extends Task {
     return problemFinderWrapper
   }
 
-  private workerBody(objects: OwnedRoomObjects): BodyPartConstant[] {
+  private workerBody(energyCapacity: number): BodyPartConstant[] {
     const maximumCarryUnitCount = 6 // TODO: 算出する
     const unit: BodyPartConstant[] = [CARRY, WORK, MOVE]
 
@@ -132,7 +134,6 @@ export class GeneralWorkerTask extends Task {
       return result
     })
 
-    const energyCapacity = objects.controller.room.energyCapacityAvailable
     for (let i = maximumCarryUnitCount; i >= 1; i -= 1) {
       const body = constructBody(i)
       const cost = bodyCost(body)

--- a/src/v5_task/worker/primitive_worker_task.ts
+++ b/src/v5_task/worker/primitive_worker_task.ts
@@ -101,7 +101,7 @@ export class PrimitiveWorkerTask extends Task {
       if (neighbourRoomInfo == null) {
         return []
       }
-      if (neighbourRoomInfo.roomType !== "normal") {
+      if (neighbourRoomInfo.roomType !== "normal" || roomTypeOf(neighbourRoomName) !== "normal") {
         return []
       }
       if (neighbourRoomInfo.owner != null) {

--- a/src/v5_task/worker/primitive_worker_task.ts
+++ b/src/v5_task/worker/primitive_worker_task.ts
@@ -192,7 +192,7 @@ export class PrimitiveWorkerTask extends Task {
 
     const requiredCreepCount = getRequiredCreepCount(ownedRoomSourceEnergyCapacity, 3) + getRequiredCreepCount(estimatedNeighbourSourceEnergyCapacity, 4)
     const maxCreepCount = objects.sources.length * 8 + neighbourRoomSourceCount * 10
-    const creepCount = Math.min(requiredCreepCount, maxCreepCount)
+    const creepCount = Math.min(requiredCreepCount, maxCreepCount, 60)
 
     return {
       creepCount,
@@ -221,7 +221,7 @@ export class PrimitiveWorkerTask extends Task {
         }
       }
 
-      if (this.neighboursToObserve.length > 0 && objects.controller.level >= 2) {
+      if (this.neighboursToObserve.length > 0) {
         const removeRoomName = (roomName: RoomName): void => {
           const index = this.neighboursToObserve.indexOf(roomName)
           if (index < 0) {

--- a/src/v5_task/worker/worker_task.ts
+++ b/src/v5_task/worker/worker_task.ts
@@ -133,7 +133,7 @@ export class WorkerTask extends Task {
 
   // ---- Private ---- //
   private checkPrimitiveWorkerTask(primitiveWorkerTask: PrimitiveWorkerTask, objects: OwnedRoomObjects): void {
-    if (objects.activeStructures.storage == null) { // TODO: 条件を詰める
+    if (objects.activeStructures.storage == null || objects.activeStructures.storage.my != null) { // TODO: 条件を詰める
       return
     }
     this.removeChildTask(primitiveWorkerTask)
@@ -144,7 +144,7 @@ export class WorkerTask extends Task {
   }
 
   private checkGeneralWorkerTask(generalWorkerTask: GeneralWorkerTask, objects: OwnedRoomObjects): void {
-    if (objects.activeStructures.storage == null) {
+    if (objects.activeStructures.storage == null || objects.activeStructures.storage.my != null) {
       return
     }
     if (objects.activeStructures.storage.store.getUsedCapacity(RESOURCE_ENERGY) < 50000) {  // TODO: 条件を詰める

--- a/src/world_info/creep_info.ts
+++ b/src/world_info/creep_info.ts
@@ -57,7 +57,9 @@ export const Creeps: CreepsInterface = {
         delete Memory.creeps[creepName]
         continue
       }
-      creep.notifyWhenAttacked(false)
+      if (creep.ticksToLive == null) {
+        creep.notifyWhenAttacked(false)
+      }
       if (!isV5CreepMemory(creep.memory)) {
         continue
       }

--- a/src/world_info/room_info.ts
+++ b/src/world_info/room_info.ts
@@ -114,7 +114,7 @@ export const Rooms: RoomsInterface = {
     if (Game.time % 107 === 13) {
       roomVersions.forEach((roomNames, version) => {
         if (roomNames.length <= 6) {
-          PrimitiveLogger.log(`${version} rooms: ${roomNames.map(name => roomLink(name)).join(", ")}`)
+          PrimitiveLogger.log(`${roomNames.length} ${version} rooms: ${roomNames.map(name => roomLink(name)).join(", ")}`)
           return
         }
         const sectors = new ValuedArrayMap<string, RoomName>()
@@ -126,7 +126,7 @@ export const Rooms: RoomsInterface = {
           }
           sectors.getValueFor(sectorName).push(roomName)
         })
-        PrimitiveLogger.log(`${version} rooms:\n${Array.from(sectors.entries()).map(([sectorName, roomNames]) => `- ${sectorName}: ${roomNames.map(r => roomLink(r)).join(", ")}`).join("\n")}`)
+        PrimitiveLogger.log(`${roomNames.length} ${version} rooms:\n${Array.from(sectors.entries()).map(([sectorName, roomNames]) => `- ${sectorName}: ${roomNames.map(r => roomLink(r)).join(", ")}`).join("\n")}`)
       })
     }
 

--- a/src/world_info/spawn_info.ts
+++ b/src/world_info/spawn_info.ts
@@ -22,6 +22,11 @@ export const Spawns: SpawnsInterface = {
       //   delete Memory.spawns[spawnName]
       //   return
       // }
+      if (spawn.room.name === "W45S3") {  // FixMe:
+        if (spawn.isActive() !== true) {
+          return
+        }
+      }
       allSpawns.push(spawn)
     })
 


### PR DESCRIPTION
- v7系
- portal偵察
- sk harvest
- compoundsを生成して圧縮

---

# Automation
- [ ] Scouting
- [ ] Launch Bootstrap Task
- [ ] (optional) Surrounding Ramparts
- [ ] (optional) attack
- 問題
  - UpgraderがContainerをブロックする
  - UpgraderのEnergy消費速度が速すぎる
  - Builderが建てる暇がない

---
- Room Plan
  - 機能をもつStructureを設置する際に周囲のRoadも一緒に設置する
  - Blockの配置状況を算出してから機能を割り振る
- 細い通路に建設する問題
  - ~cellular automataで壁に囲われた場所を壁としてから計算する~  
  - スコアが46にかかっていないblockは建設しない
- Scout
  - room memoryに保存
    - sourceの数
    - exit to (room name)
    - center position
    - 敵の有無
- Spawnからの記録をつける


# Debugging
- Task/Processがある程度人語による質問を受け付けるようにする
  - What/Where/Why/When/How

# v7構想
- 宣言的
- ProcessのインターフェースをTaskに取り入れる
  - 親子関係を必要としていたのはcost/benefit産出および子タスクの問題解決のためであり、掲示板等の仕組みで吸収できるのであればProcessにしても良い
- Cost/Benefit

---
- [ ] Taskのインターフェースを定義する
- [ ] 掲示板のインターフェースを定義する

---

- 宣言的インターフェース
  - 条件を満たす状態と現状の差分を無くす行動を行う
    - MECEになっていれば必ず行動を選択できる
      - 未実装条件は問題を上げる
  - boost compoundsを揃える
    - 他所にあれば引き出す
    - 無ければrun reaction
    - 無ければharvest
  - 掲示板システムが必要
- Task
  - 個々のTaskを直接操作可能にする

# v6
- 異なるBotを起動する際、それぞれ異なるアプリケーションを動作させたい場合など
  - ApplicationLauncherをProcess化し、環境ごとにスタートアップProcessを書き込んでおけば良いのではないか
- RoomKeeperは部屋のOSである
  - インターフェースに準拠した下位タスクを優先順位づけし、実行する
- 継続するタスクは常時実行される
  - イベントドリブンを実装すれば計算量が減る

# Quad
- 攻撃力最大化
  - 常に回復し続けられれば最小限のTOUGHで済む
- 計算量削減
  - Pathの再利用
  - 地形のキャッシュ
  - Direction計算最適化
- [ ] meleeの近くを通るPathを選択してしまう
- [ ] align時にQuad形態が崩れる
- [ ] **Exitの方向を向いていない場合に部屋から出られない**
- [ ] Exit/enter時にQuad形態が崩れる→ignoreCreepで直ったか？
- [ ] leader以外の最適攻撃範囲を考慮できていない

---

- アカウント名を動的に取得
- 配置のパターンを認識できるようにする
- CreepTask再編
  - Simultaneous Actionを同時に行えるようにする
    - →スロット制？
    - API的に同時に行えない行動とそうでないもの
      - →flee&moveto
- HarvesterをPullすることでSpawn時間短縮
- v5Taskを単体でv6へ変更可能にする
- isActiveを直接呼び出すのではなくERR_RCL_NOT_ENOUGHを参照するようにする
- UnresolvedProblemを正規化しMemoryに保存しておく
- Structureごとに要求を出させて、それを集計する
  - リソースを複数のStructureへ運ぶ
  - 複数のリソースをひとつのStructureへ運ぶ
- 複数のCreepTaskを優先順位づけし実行するcombined task
- 2tickかかるCreepTask（MoveToPosition等）を終了させるため、TaskのAssign前にステータスチェックを行えるようにする（optional
  - decode時に行えば良いか
- v6
  - economy performanceをどのように計測するか -> https://docs.screeps.com/api/#Room.getEventLog
- CreepTask実行時にCPU時間考慮を行う
- MoveToRoom時に境界で止まると戻ってきてしまう
  - TOP_LEFTとTOPを同時に呼び出すと実行できるもののみ実行されないか
- [ ] Create Construction SiteもTask Requestにする
- [ ] v5タスクがランタイムエラーを起こすとタスクが停止することがある
- [ ] まとめられるログ用のログインターフェースを追加する：（`Season701205PowerHarvesterSwampRunnerProcess for W0S0, E0N0 finished`
- v6系migration
  - v5系Processをsuspendした状態でBridging Taskを介してv6系Processから動作させる
  - migrationが完了したらv5系Processは停止する
- [ ] PowerCreep用ApiWrapperを作成する
  - [ ] CreepTaskはCreepTask<T extends AnyCreep>
- 特定のcreepのタスクのアサイン状況をログ出力できるようにする
- 管理creepの状態を取得できる必要がある
  - CreepTaskに現在どのような状態で見積もりはどうであるか説明させる
- CreepTaskは対比用効果を算出する
  - 最終的には全ての行動を数値化して意思決定する
    - 重みを変更することで行動を変化させられる
- Haulerが自動で割り当てられるようにしたい
  - →Energy Request, Energy Sourceを出しているオブジェクトに対して十分なHaulerが生成される
- Room間移動コスト算出方法
  - 各部屋独立して各辺から他辺への移動コストを算出しておき、それを集計する
  - 迷路solverと同様に解ける
- 地形の同定に四分木を導入したらどうか